### PR TITLE
[FIX] Explicitly include BouncyCastle dependency to classpath

### DIFF
--- a/cos-fleetshard-operator/pom.xml
+++ b/cos-fleetshard-operator/pom.xml
@@ -77,6 +77,17 @@
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-ext-jdk15on</artifactId>
+            <version>${bouncycastle.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>${bouncycastle.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <openapi-generator-maven-plugin.version>5.1.0</openapi-generator-maven-plugin.version>
         <meven-resources-plugin.version>3.2.0</meven-resources-plugin.version>
+        <bouncycastle.version>1.68</bouncycastle.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
I got following error when building:

```
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:1.12.2.Final:build (default) on project cos-fleetshard-operator: Failed to build quarkus application: io.quarkus.builder.BuildException: Build failu
re: Build failed due to errors
[ERROR]         [error]: Build step io.quarkus.kubernetes.client.deployment.KubernetesClientBuildStep#process threw an exception: io.fabric8.kubernetes.client.KubernetesClientException: JcaPEMKeyConverter is pro
vided by BouncyCastle, an optional dependency. To use support for EC Keys you must explicitly add this dependency to classpath.
```

Including BouncyCastle as a dependency fixed it.