### PR TITLE
chore(rbac): Add extra RBAC resources

### DIFF
--- a/cos-fleetshard-operator/src/main/kubernetes/kubernetes.yml
+++ b/cos-fleetshard-operator/src/main/kubernetes/kubernetes.yml
@@ -1,0 +1,88 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: view-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  resourceNames:
+  - addon-cos-fleetshard-operator-parameters
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cos-fleetshard-operator
+rules:
+# operator custom resources
+- apiGroups:
+  - cos.bf2.org
+  resources:
+  - managedconnectors
+  - managedconnectors/status
+  - managedconnectoroperators
+  - managedconnectoroperators/status
+  - managedconnectorclusters
+  - managedconnectorclusters/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+# managed connector resources
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkaconnects
+  - kafkaconnectors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - camel.apache.org
+  resources:
+  - kameletbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cos-fleetshard-operator
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: cos-fleetshard-operator
+subjects:
+- kind: ServiceAccount
+  name: cos-fleetshard

--- a/etc/kubernetes/kubernetes.yml
+++ b/etc/kubernetes/kubernetes.yml
@@ -5,9 +5,9 @@ metadata:
   annotations:
     prometheus.io/port: "8080"
     prometheus.io/scheme: http
-    app.quarkus.io/commit-id: 924c7ed21250073d571a8bf576adf47b34e5e4c7
+    app.quarkus.io/commit-id: 9ea3a3348d6bca3cf5b730144aa4770d4f5235ef
     app.quarkus.io/vcs-url: https://github.com/bf2fc6cc711aee1a0c2a/cos-fleetshard.git
-    app.quarkus.io/build-timestamp: 2021-06-21 - 15:50:40 +0000
+    app.quarkus.io/build-timestamp: 2021-06-22 - 13:39:48 +0000
     prometheus.io/scrape: "true"
     prometheus.io/path: /q/metrics
   labels:
@@ -21,9 +21,9 @@ metadata:
   annotations:
     prometheus.io/port: "8080"
     prometheus.io/scheme: http
-    app.quarkus.io/commit-id: 924c7ed21250073d571a8bf576adf47b34e5e4c7
+    app.quarkus.io/commit-id: 9ea3a3348d6bca3cf5b730144aa4770d4f5235ef
     app.quarkus.io/vcs-url: https://github.com/bf2fc6cc711aee1a0c2a/cos-fleetshard.git
-    app.quarkus.io/build-timestamp: 2021-06-21 - 15:50:40 +0000
+    app.quarkus.io/build-timestamp: 2021-06-22 - 13:39:48 +0000
     prometheus.io/scrape: "true"
     prometheus.io/path: /q/metrics
   labels:
@@ -43,14 +43,88 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: view-secrets
+  name: cos-fleetshard-operator
 rules:
+- apiGroups:
+  - cos.bf2.org
+  resources:
+  - managedconnectors
+  - managedconnectors/status
+  - managedconnectoroperators
+  - managedconnectoroperators/status
+  - managedconnectorclusters
+  - managedconnectorclusters/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:
   - secrets
   verbs:
+  - create
+  - delete
   - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkaconnects
+  - kafkaconnectors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - camel.apache.org
+  resources:
+  - kameletbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: view-secrets
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - addon-cos-fleetshard-operator-parameters
+  resources:
+  - secrets
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cos-fleetshard-operator
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: cos-fleetshard-operator
+subjects:
+- kind: ServiceAccount
+  name: cos-fleetshard
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -82,9 +156,9 @@ metadata:
   annotations:
     prometheus.io/port: "8080"
     prometheus.io/scheme: http
-    app.quarkus.io/commit-id: 924c7ed21250073d571a8bf576adf47b34e5e4c7
+    app.quarkus.io/commit-id: 9ea3a3348d6bca3cf5b730144aa4770d4f5235ef
     app.quarkus.io/vcs-url: https://github.com/bf2fc6cc711aee1a0c2a/cos-fleetshard.git
-    app.quarkus.io/build-timestamp: 2021-06-21 - 15:50:40 +0000
+    app.quarkus.io/build-timestamp: 2021-06-22 - 13:39:48 +0000
     prometheus.io/scrape: "true"
     prometheus.io/path: /q/metrics
   labels:
@@ -102,9 +176,9 @@ spec:
       annotations:
         prometheus.io/port: "8080"
         prometheus.io/scheme: http
-        app.quarkus.io/commit-id: 924c7ed21250073d571a8bf576adf47b34e5e4c7
+        app.quarkus.io/commit-id: 9ea3a3348d6bca3cf5b730144aa4770d4f5235ef
         app.quarkus.io/vcs-url: https://github.com/bf2fc6cc711aee1a0c2a/cos-fleetshard.git
-        app.quarkus.io/build-timestamp: 2021-06-21 - 15:50:40 +0000
+        app.quarkus.io/build-timestamp: 2021-06-22 - 13:39:48 +0000
         prometheus.io/scrape: "true"
         prometheus.io/path: /q/metrics
       labels:


### PR DESCRIPTION
An attempt at defining extra RBAC resources that are required. It must be adapted depending on the deployment model for the resources owned by the ManagedConnectors. The proposed changes assume these are created in the same namespace as the operator.