### PR TITLE
MGDSTRM-4440 - Add Micrometer to cos-fleetshard

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ kubectl create configmap cos-fleetshard-config \
 
 #
 # create operator secret
-#  
+#
 # NOTE: the file in etc/kubernetes/app-secret/application.properties is
 #       only a template, copy it somewhere and adapt the command below
 #       and remember not to commit it
-#      
-kubectl create configmap addon-cos-fleetshard-operator-parameters \
+#
+kubectl create secret generic addon-cos-fleetshard-operator-parameters \
   --from-file=etc/kubernetes/app-secret/application.properties
-               
+
 # build
 ./mvnw install
 

--- a/cos-fleetshard-operator-core/pom.xml
+++ b/cos-fleetshard-operator-core/pom.xml
@@ -46,6 +46,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-scheduler</artifactId>
         </dependency>
         <dependency>

--- a/cos-fleetshard-operator/pom.xml
+++ b/cos-fleetshard-operator/pom.xml
@@ -44,10 +44,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kubernetes-config</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
The micrometer dependency is already in the project but I moved it to cos-fleetshard-operator-core, where we'll use it in the code. The metrics endpoint is http:/<host>:<port>/q/metrics.