### PR TITLE
MGDSTRM-4440 Expose cos-fleetshard metrics

### DIFF
--- a/cos-fleetshard-operator/src/main/resources/application-dev.properties
+++ b/cos-fleetshard-operator/src/main/resources/application-dev.properties
@@ -20,8 +20,3 @@ quarkus.http.port = 8088
 #   https://github.com/fabric8io/kubernetes-client/issues/2888
 #
 quarkus.kubernetes-client.trust-certs      = true
-
-#
-# https://github.com/quarkusio/quarkus/issues/16130
-#
-quarkus.micrometer.binder.vertx.enabled = false

--- a/cos-fleetshard-operator/src/main/resources/application.properties
+++ b/cos-fleetshard-operator/src/main/resources/application.properties
@@ -33,3 +33,8 @@ quarkus.oidc-client-filter.register-filter     = false
 quarkus.oidc-client.auth-server-url            = ${mas-sso-base-url}/auth/realms/${mas-sso-realm}
 quarkus.oidc-client.client-id                  = ${client-id}
 quarkus.oidc-client.credentials.secret         = ${client-secret}
+
+quarkus.micrometer.binder.http-client.enabled = false
+quarkus.micrometer.binder.http-server.enabled = false
+quarkus.micrometer.binder.jvm = false
+quarkus.micrometer.binder.system = false


### PR DESCRIPTION
Out-of-the-box metrics are disabled to avoid unnecessary disk usage. The `up` metrics is automatically created by Prometheus on the server side.