### PR TITLE
chore: add quarkus-core to cos-fleetshard-api dependencies

### DIFF
--- a/cos-fleetshard-api/pom.xml
+++ b/cos-fleetshard-api/pom.xml
@@ -17,6 +17,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.sundr</groupId>
             <artifactId>builder-annotations</artifactId>
         </dependency>
@@ -38,12 +43,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The goal here is to include dependencies expected by the kubernetes crd generator and avoid misleading warning 