### PR TITLE
MGDSTRM-5612: cos-fleetshard : support migrating connector between operators.

### DIFF
--- a/cos-fleetshard-it/cucumber/src/main/java/org/bf2/cos/fleetshard/it/cucumber/ConnectorSteps.java
+++ b/cos-fleetshard-it/cucumber/src/main/java/org/bf2/cos/fleetshard/it/cucumber/ConnectorSteps.java
@@ -284,6 +284,17 @@ public class ConnectorSteps {
         });
     }
 
+    @And("the connector's assignedOperator does not exist")
+    public void connector_assignedOperator_not_exists() {
+        untilConnector(c -> {
+            Operator op = c.getStatus().getConnectorStatus().getAssignedOperator();
+            return op != null
+                && op.getId() == null
+                && op.getType() == null
+                && op.getVersion() == null;
+        });
+    }
+
     @Then("the connector's availableOperator exists with:")
     public void connector_availableOperator_exists_with(Map<String, String> expected) {
         var res = kubernetesClient.resources(ManagedConnector.class)
@@ -309,6 +320,13 @@ public class ConnectorSteps {
         assertThat(op.getId()).isEqualTo(null);
         assertThat(op.getType()).isEqualTo(null);
         assertThat(op.getVersion()).isEqualTo(null);
+    }
+
+    @Then("the connector operatorSelector id is {string}")
+    public void connector_operator_selector_id(String selectorId) {
+        untilConnector(c -> {
+            return selectorId.equals(c.getSpec().getOperatorSelector().getId());
+        });
     }
 
     private void until(Callable<Boolean> conditionEvaluator) {

--- a/cos-fleetshard-operator-it/src/main/resources/application.properties
+++ b/cos-fleetshard-operator-it/src/main/resources/application.properties
@@ -37,3 +37,5 @@ quarkus.operator-sdk.controllers."connector".namespaces = ${cos.connectors.names
 
 cos.operator.id = cos-fleetshard-operator-it
 cos.operator.version = 1.5.0
+
+cos.connectors.metrics.connectoroperand.enabled = true

--- a/cos-fleetshard-operator-it/src/test/java/org/bf2/cos/fleetshard/operator/it/ConnectorOperatorsMigrationTest.java
+++ b/cos-fleetshard-operator-it/src/test/java/org/bf2/cos/fleetshard/operator/it/ConnectorOperatorsMigrationTest.java
@@ -1,0 +1,33 @@
+package org.bf2.cos.fleetshard.operator.it;
+
+import java.util.Map;
+
+import io.quarkiverse.cucumber.CucumberOptions;
+import io.quarkiverse.cucumber.CucumberQuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+import static org.bf2.cos.fleetshard.support.resources.Resources.uid;
+
+@CucumberOptions(
+    features = {
+        "classpath:ConnectorOperatorsMigration.feature"
+    },
+    glue = {
+        "org.bf2.cos.fleetshard.it.cucumber",
+    })
+@TestProfile(ConnectorOperatorsMigrationTest.Profile.class)
+public class ConnectorOperatorsMigrationTest extends CucumberQuarkusTest {
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            final String ns = "cos-" + uid();
+
+            return Map.of(
+                "test.namespace", ns,
+                "cos.connectors.namespace", ns,
+                "cos.operators.namespace", ns,
+                "cos.cluster.id", uid());
+        }
+    }
+}

--- a/cos-fleetshard-operator-it/src/test/java/org/bf2/cos/fleetshard/operator/it/support/TestProducers.java
+++ b/cos-fleetshard-operator-it/src/test/java/org/bf2/cos/fleetshard/operator/it/support/TestProducers.java
@@ -63,12 +63,12 @@ public class TestProducers {
 
             @Override
             public boolean stop(ManagedConnector connector) {
-                return false;
+                return true;
             }
 
             @Override
             public boolean delete(ManagedConnector connector) {
-                return false;
+                return true;
             }
         };
     }

--- a/cos-fleetshard-operator-it/src/test/resources/ConnectorMultipleOperators.feature
+++ b/cos-fleetshard-operator-it/src/test/resources/ConnectorMultipleOperators.feature
@@ -38,4 +38,3 @@ Feature: Connector Multiple Operators
       | operator.id      | cos-fleetshard-operator-2-it |
       | operator.type    | connector-operator-it        |
       | operator.version | 1.6.0                        |
-

--- a/cos-fleetshard-operator-it/src/test/resources/ConnectorOperatorsMigration.feature
+++ b/cos-fleetshard-operator-it/src/test/resources/ConnectorOperatorsMigration.feature
@@ -1,0 +1,54 @@
+Feature: Connector Multiple Operators
+
+  Background:
+    Given Await configuration
+      | atMost       | 30000   |
+      | pollDelay    | 100     |
+      | pollInterval | 500     |
+
+  Scenario: The Operator stop managing a connector in order to migrate it to another operator
+    Given a Connector with:
+      | connector.type.id           | log_sink_0.1                    |
+      | desired.state               | ready                           |
+      | kafka.bootstrap             | kafka.acme.com:443              |
+      | operator.id                 | cos-fleetshard-operator-it      |
+      | operator.type               | connector-operator-it           |
+      | operator.version            | [1.0.0,2.0.0)                   |
+
+    When deploy
+    Then the connector exists
+    Then the connector secret exists
+    Then the connector operatorSelector id is "cos-fleetshard-operator-it"
+    Then the connector's assignedOperator exists with:
+      | operator.id      | cos-fleetshard-operator-it |
+      | operator.type    | connector-operator-it      |
+      | operator.version | 1.5.0                      |
+
+    When the connector path "spec.operatorSelector.id" is set to "cos-fleetshard-operator-it-new"
+    Then the connector is in phase "Initialization"
+    And the connector's availableOperator does not exist
+    And the connector's assignedOperator does not exist
+    And the meters has counter "cos.fleetshard.controller.event.operators.operand.stop.count" with value equal to 1
+
+  Scenario: The Operator start managing a connector that has been migrated from another operator
+    Given a Connector with:
+      | connector.type.id           | log_sink_0.1                    |
+      | desired.state               | ready                           |
+      | kafka.bootstrap             | kafka.acme.com:443              |
+      | operator.id                 | cos-fleetshard-operator-it-old  |
+      | operator.type               | connector-operator-it           |
+      | operator.version            | [1.0.0,2.0.0)                   |
+
+    When deploy
+    Then the connector exists
+    Then the connector secret exists
+    Then the connector operatorSelector id is "cos-fleetshard-operator-it-old"
+    And the connector's availableOperator does not exist
+    And the connector's assignedOperator does not exist
+
+    When the connector path "spec.operatorSelector.id" is set to "cos-fleetshard-operator-it"
+    Then the connector's assignedOperator exists with:
+      | operator.id      | cos-fleetshard-operator-it |
+      | operator.type    | connector-operator-it      |
+      | operator.version | 1.5.0                      |
+    Then the connector is in phase "Monitor"

--- a/cos-fleetshard-operator/src/main/java/org/bf2/cos/fleetshard/operator/operand/OperandControllerMetricsWrapper.java
+++ b/cos-fleetshard-operator/src/main/java/org/bf2/cos/fleetshard/operator/operand/OperandControllerMetricsWrapper.java
@@ -1,0 +1,50 @@
+package org.bf2.cos.fleetshard.operator.operand;
+
+import java.util.List;
+
+import org.bf2.cos.fleetshard.api.ManagedConnector;
+import org.bf2.cos.fleetshard.operator.support.MetricsRecorder;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext;
+
+public class OperandControllerMetricsWrapper implements OperandController {
+    private OperandController wrappedOperandController;
+    private MetricsRecorder metricsRecorder;
+
+    public OperandControllerMetricsWrapper(OperandController wrappedOperandController, MetricsRecorder metricsRecorder) {
+        this.wrappedOperandController = wrappedOperandController;
+        this.metricsRecorder = metricsRecorder;
+    }
+
+    @Override
+    public List<ResourceDefinitionContext> getResourceTypes() {
+        return metricsRecorder.recordCallable(
+            () -> wrappedOperandController.getResourceTypes(), ".getResourceTypes");
+    }
+
+    @Override
+    public List<HasMetadata> reify(ManagedConnector connector, Secret secret) {
+        return metricsRecorder.recordCallable(
+            () -> wrappedOperandController.reify(connector, secret), ".reify");
+    }
+
+    @Override
+    public void status(ManagedConnector connector) {
+        metricsRecorder.record(
+            () -> wrappedOperandController.status(connector), ".status");
+    }
+
+    @Override
+    public boolean stop(ManagedConnector connector) {
+        return metricsRecorder.recordCallable(
+            () -> wrappedOperandController.stop(connector), ".stop");
+    }
+
+    @Override
+    public boolean delete(ManagedConnector connector) {
+        return metricsRecorder.recordCallable(
+            () -> wrappedOperandController.delete(connector), ".delete");
+    }
+}

--- a/cos-fleetshard-operator/src/main/java/org/bf2/cos/fleetshard/operator/support/MetricsRecorder.java
+++ b/cos-fleetshard-operator/src/main/java/org/bf2/cos/fleetshard/operator/support/MetricsRecorder.java
@@ -21,53 +21,61 @@ public class MetricsRecorder {
     }
 
     public void record(Runnable action) {
+        record(action, "");
+    }
+
+    public void record(Runnable action, String subId) {
         try {
-            Timer.builder(id + ".time")
+            Timer.builder(id + subId + ".time")
                 .tags(tags)
                 .publishPercentiles(0.3, 0.5, 0.95)
                 .publishPercentileHistogram()
                 .register(registry)
                 .record(action);
 
-            Counter.builder(id + ".count")
+            Counter.builder(id + subId + ".count")
                 .tags(tags)
                 .register(registry)
                 .increment();
 
         } catch (Exception e) {
-            Counter.builder(id + ".count.failure")
+            Counter.builder(id + subId + ".count.failure")
                 .tags(tags)
                 .tag("exception", e.getClass().getName())
                 .register(registry)
                 .increment();
 
-            throw new RuntimeException("Failure recording method execution (id: " + id + ")", e);
+            throw new RuntimeException("Failure recording method execution (id: " + id + subId + ")", e);
         }
     }
 
     public <T> T recordCallable(Callable<T> action) {
+        return recordCallable(action, "");
+    }
+
+    public <T> T recordCallable(Callable<T> action, String subId) {
         try {
-            var answer = Timer.builder(id + ".time")
+            var answer = Timer.builder(id + subId + ".time")
                 .tags(tags)
                 .publishPercentiles(0.3, 0.5, 0.95)
                 .publishPercentileHistogram()
                 .register(registry)
                 .recordCallable(action);
 
-            Counter.builder(id + ".count")
+            Counter.builder(id + subId + ".count")
                 .tags(tags)
                 .register(registry)
                 .increment();
 
             return answer;
         } catch (Exception e) {
-            Counter.builder(id + ".count.failure")
+            Counter.builder(id + subId + ".count.failure")
                 .tags(tags)
                 .tag("exception", e.getClass().getName())
                 .register(registry)
                 .increment();
 
-            throw new RuntimeException("Failure recording method execution (id: " + id + ")", e);
+            throw new RuntimeException("Failure recording method execution (id: " + id + subId + ")", e);
         }
     }
 

--- a/etc/kubernetes/sync/base/kubernetes.yml
+++ b/etc/kubernetes/sync/base/kubernetes.yml
@@ -152,10 +152,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: "metadata.namespace"
-        - name: "SMALLRYE_CONFIG_LOCATIONS"
-          value: "/mnt/app-config"
         - name: "SMALLRYE_CONFIG_SOURCE_FILE_LOCATIONS"
           value: "/mnt/app-secret"
+        - name: "SMALLRYE_CONFIG_LOCATIONS"
+          value: "/mnt/app-config"
         image: "quay.io/rhoas/cos-fleetshard-sync:latest"
         imagePullPolicy: "Always"
         livenessProbe:


### PR DESCRIPTION
- cos-fleetshard  support migrating connectors between operators according to [ADR-00063](https://docs.google.com/document/d/1zcjdBGpwkhDiWLQetARO46Bbo8YpenHkNTM0EjIQ1Bo/edit?usp=sharing) there is a [demo of the reature](https://drive.google.com/file/d/1RQz5w04Ao5pcIBFIivc3AIeutvMLEaIA/view?usp=sharing)
- the MetricsRecorder  accept `subId` parameter.
- an Operand wrapper (`org.bf2.cos.fleetshard.operator.operand.OperandControllerMetricsWrapper`) that adds metrics to count operand methods calls has been added. It can be enabled by setting `cos.connectors.metrics.connectoroperand.enabled = true` property.
- some cucumber steps were added. 