### PR TITLE
fix(camel): force openshift profile

### DIFF
--- a/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelConstants.java
+++ b/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelConstants.java
@@ -16,6 +16,8 @@ public final class CamelConstants {
     public static final String CONNECTOR_TYPE_SOURCE = "source";
     public static final String CONNECTOR_TYPE_SINK = "sink";
 
+    public static final String CAMEL_K_PROFILE_OPENSHIFT = "OpenShift";
+
     public static final String TRAIT_CAMEL_APACHE_ORG_ENV = "trait.camel.apache.org/environment.%s";
     public static final String TRAIT_CAMEL_APACHE_ORG_CONTAINER_IMAGE = "trait.camel.apache.org/container.image";
     public static final String TRAIT_CAMEL_APACHE_ORG_KAMELETS_ENABLED = "trait.camel.apache.org/kamelets.enabled";

--- a/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandSupport.java
+++ b/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandSupport.java
@@ -217,6 +217,7 @@ public final class CamelOperandSupport {
         Map<String, String> envVars) {
 
         ObjectNode integration = Serialization.jsonMapper().createObjectNode();
+        integration.put("profile", CamelConstants.CAMEL_K_PROFILE_OPENSHIFT);
         ArrayNode configuration = integration.withArray("configuration");
 
         configuration.addObject()

--- a/cos-fleetshard-operator-camel/src/test/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandControllerTest.java
+++ b/cos-fleetshard-operator-camel/src/test/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandControllerTest.java
@@ -141,6 +141,8 @@ public final class CamelOperandControllerTest {
                     .containsEntry(TRAIT_CAMEL_APACHE_ORG_HEALTH_READINESS_PROBE_ENABLED, "true");
 
                 assertThat(resource).isInstanceOfSatisfying(KameletBinding.class, binding -> {
+                    assertThat(binding.getSpec().getIntegration().get("profile").textValue())
+                        .isEqualTo(CamelConstants.CAMEL_K_PROFILE_OPENSHIFT);
                     assertThat(binding.getSpec().getSource().getRef())
                         .hasFieldOrPropertyWithValue("apiVersion", Kamelet.RESOURCE_API_VERSION)
                         .hasFieldOrPropertyWithValue("kind", Kamelet.RESOURCE_KIND)

--- a/etc/kubernetes/sync/base/kubernetes.yml
+++ b/etc/kubernetes/sync/base/kubernetes.yml
@@ -152,10 +152,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: "metadata.namespace"
-        - name: "SMALLRYE_CONFIG_LOCATIONS"
-          value: "/mnt/app-config"
         - name: "SMALLRYE_CONFIG_SOURCE_FILE_LOCATIONS"
           value: "/mnt/app-secret"
+        - name: "SMALLRYE_CONFIG_LOCATIONS"
+          value: "/mnt/app-config"
         image: "quay.io/rhoas/cos-fleetshard-sync:latest"
         imagePullPolicy: "Always"
         livenessProbe:


### PR DESCRIPTION
In case knative is installed or the related CRDs are registered, the camel-k operator assumes it should use knative to run the connectors which could break some of them. 

Which this pr the OpenShift profile is enforced