### PR TITLE
MGDCTRS-79: enables Camel Exchange Pooling by default

### DIFF
--- a/cos-fleetshard-operator-camel-it/src/test/java/org/bf2/cos/fleetshard/operator/it/camel/CamelConnectorReifyTest.java
+++ b/cos-fleetshard-operator-camel-it/src/test/java/org/bf2/cos/fleetshard/operator/it/camel/CamelConnectorReifyTest.java
@@ -40,6 +40,9 @@ public class CamelConnectorReifyTest extends CucumberQuarkusTest {
             configs.put("cos.operator.camel.health.liveness-failure-threshold", "6");
             configs.put("cos.operator.camel.health.liveness-period-seconds", "7");
             configs.put("cos.operator.camel.health.liveness-timeout-seconds", "8");
+            configs.put("cos.operator.camel.exchange-pooling.exchange-factory", "prototype");
+            configs.put("cos.operator.camel.exchange-pooling.exchange-factory-capacity", "31");
+            configs.put("cos.operator.camel.exchange-pooling.exchange-factory-statistics-enabled", "true");
             return configs;
         }
     }

--- a/cos-fleetshard-operator-camel-it/src/test/resources/CamelConnectorReify.feature
+++ b/cos-fleetshard-operator-camel-it/src/test/resources/CamelConnectorReify.feature
@@ -51,6 +51,9 @@ Feature: Camel Connector Reify
           | { "type":"property" , "value": "camel.main.route-controller-backoff-delay=2s" }            |
           | { "type":"property" , "value": "camel.main.route-controller-initial-delay=1s" }            |
           | { "type":"property" , "value": "camel.main.route-controller-backoff-multiplier=2" }        |
+          | { "type":"property" , "value": "camel.main.exchange-factory=prototype" }                   |
+          | { "type":"property" , "value": "camel.main.exchange-factory-capacity=31" }                 |
+          | { "type":"property" , "value": "camel.main.exchange-factory-statistics-enabled=true" }     |
 
     And the klb has an entry at path "$.metadata.ownerReferences[0].apiVersion" with value "cos.bf2.org/v1alpha1"
     And the klb has an entry at path "$.metadata.ownerReferences[0].kind" with value "ManagedConnector"

--- a/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandConfiguration.java
+++ b/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandConfiguration.java
@@ -9,6 +9,8 @@ public interface CamelOperandConfiguration {
 
     Health health();
 
+    ExchangePooling exchangePooling();
+
     interface RouteController {
         @WithDefault("10s")
         String backoffDelay();
@@ -44,5 +46,16 @@ public interface CamelOperandConfiguration {
 
         @WithDefault("1")
         String readinessTimeoutSeconds();
+    }
+
+    interface ExchangePooling {
+        @WithDefault("pooled")
+        String exchangeFactory();
+
+        @WithDefault("100")
+        String exchangeFactoryCapacity();
+
+        @WithDefault("false")
+        String exchangeFactoryStatisticsEnabled();
     }
 }

--- a/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandSupport.java
+++ b/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandSupport.java
@@ -245,6 +245,21 @@ public final class CamelOperandSupport {
                     + cfg.routeController().backoffMultiplier());
         }
 
+        if (cfg.exchangePooling() != null) {
+            configuration.addObject()
+                .put("type", "property")
+                .put("value", "camel.main.exchange-factory="
+                    + cfg.exchangePooling().exchangeFactory());
+            configuration.addObject()
+                .put("type", "property")
+                .put("value", "camel.main.exchange-factory-capacity="
+                    + cfg.exchangePooling().exchangeFactoryCapacity());
+            configuration.addObject()
+                .put("type", "property")
+                .put("value", "camel.main.exchange-factory-statistics-enabled="
+                    + cfg.exchangePooling().exchangeFactoryStatisticsEnabled());
+        }
+
         return integration;
     }
 


### PR DESCRIPTION
This allows Camel to reuse Exchange classes and reduce
object allocation. New configuration properties to override
the default values are also provided.

https://issues.redhat.com/browse/MGDCTRS-79