### PR TITLE
MGDCTRS-328: applies error handling strategy to Camel K

### DIFF
--- a/cos-fleetshard-it/cucumber/src/main/java/org/bf2/cos/fleetshard/it/cucumber/ConnectorSteps.java
+++ b/cos-fleetshard-it/cucumber/src/main/java/org/bf2/cos/fleetshard/it/cucumber/ConnectorSteps.java
@@ -311,6 +311,15 @@ public class ConnectorSteps {
         });
     }
 
+    @And("the connector operand status is in phase {string}")
+    public void connector_operand_status_is_in_phase(String phase) {
+        untilConnector(c -> {
+            return Objects.equals(
+                phase,
+                c.getStatus().getConnectorStatus().getPhase());
+        });
+    }
+
     @Then("the deployment is in phase {string}")
     public void deployment_is_in_phase(String phase) {
         untilConnector(c -> {

--- a/cos-fleetshard-operator-camel-it/src/test/java/org/bf2/cos/fleetshard/operator/it/camel/glues/KameletBindingSteps.java
+++ b/cos-fleetshard-operator-camel-it/src/test/java/org/bf2/cos/fleetshard/operator/it/camel/glues/KameletBindingSteps.java
@@ -98,6 +98,25 @@ public class KameletBindingSteps extends StepsSupport {
         //            });
     }
 
+    @SuppressWarnings("unchecked")
+    @When("the klb phase is {string}")
+    public void klb_phase_and_conditions(String phase) {
+        kubernetesClient.genericKubernetesResources(KameletBinding.RESOURCE_DEFINITION)
+            .inNamespace(ctx.connector().getMetadata().getNamespace())
+            .withName(ctx.connector().getMetadata().getName())
+            .editStatus(binding -> {
+                Map<String, Object> status = (Map<String, Object>) binding.getAdditionalProperties().get("status");
+                if (status == null) {
+                    status = new HashMap<>();
+                }
+
+                status.put("phase", phase);
+                binding.getAdditionalProperties().put("status", status);
+
+                return binding;
+            });
+    }
+
     @When("the klb path {string} is set to json:")
     public void klb_pointer(String path, String payload) {
         kubernetesClient.resources(KameletBinding.class)

--- a/cos-fleetshard-operator-camel-it/src/test/resources/CamelConnectorReifyErrorHandler.feature
+++ b/cos-fleetshard-operator-camel-it/src/test/resources/CamelConnectorReifyErrorHandler.feature
@@ -46,7 +46,7 @@ Feature: Camel Connector Reify
      And the connector is in phase "Monitor"
 
     Then the klb exists
-     And the klb has an entry at path "$.spec.errorHandler.dead-letter-channel.endpoint.uri" with value "kamelet://managed-kafka-sink/error"
+     And the klb has an entry at path "$.spec.errorHandler.sink.endpoint.uri" with value "kamelet://cos-kafka-sink/error"
 
     Then the klb secret exists
      And the klb secret contains:
@@ -56,10 +56,10 @@ Feature: Camel Connector Reify
       | camel.kamelet.managed-kafka-source.password             |                            |
       | camel.kamelet.managed-kafka-source.user                 |                            |
       | camel.kamelet.managed-kafka-source.topic                | dbz_pg.inventory.customers |
-      | camel.kamelet.managed-kafka-sink.error.topic            | dlq                        |
-      | camel.kamelet.managed-kafka-sink.error.bootstrapServers | kafka.acme.com:443         |
-      | camel.kamelet.managed-kafka-sink.error.password         |                            |
-      | camel.kamelet.managed-kafka-sink.error.user             |                            |
+      | camel.kamelet.cos-kafka-sink.error.topic                | dlq                        |
+      | camel.kamelet.cos-kafka-sink.error.bootstrapServers     | kafka.acme.com:443         |
+      | camel.kamelet.cos-kafka-sink.error.password             |                            |
+      | camel.kamelet.cos-kafka-sink.error.user                 |                            |
 
   Scenario: reify stop error handler
     Given a Connector with:
@@ -79,4 +79,8 @@ Feature: Camel Connector Reify
      And the connector is in phase "Monitor"
 
     Then the klb exists
-     And the klb has an entry at path "$.spec.errorHandler.dead-letter-channel.endpoint.uri" with value "controlbus:route?routeId=current&action=stop"
+     And the klb has an entry at path "$.spec.errorHandler.sink.endpoint.uri" with value "controlbus:route?routeId=current&action=stop"
+     
+    When the klb phase is "error"
+    Then the connector is in phase "Monitor"
+     And the connector operand status is in phase "failed"

--- a/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelConstants.java
+++ b/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelConstants.java
@@ -38,8 +38,8 @@ public final class CamelConstants {
     public static final String TRAIT_CAMEL_APACHE_ORG_HEALTH_READINESS_FAILURE_THRESHOLD = "trait.camel.apache.org/health.readiness-failure-threshold";
 
     public static final String ERROR_HANDLER_LOG_TYPE = "log";
-    public static final String ERROR_HANDLER_DEAD_LETTER_CHANNEL_TYPE = "dead-letter-channel";
-    public static final String ERROR_HANDLER_DEAD_LETTER_CHANNEL_KAMELET = "managed-kafka-sink";
+    public static final String ERROR_HANDLER_SINK_CHANNEL_TYPE = "sink";
+    public static final String ERROR_HANDLER_DEAD_LETTER_CHANNEL_KAMELET = "cos-kafka-sink";
     public static final String ERROR_HANDLER_DEAD_LETTER_CHANNEL_KAMELET_ID = "error";
     public static final String ERROR_HANDLER_STOP_URI = "controlbus:route?routeId=current&action=stop";
 

--- a/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandSupport.java
+++ b/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandSupport.java
@@ -32,8 +32,8 @@ import static org.bf2.cos.fleetshard.operator.camel.CamelConstants.CONNECTOR_TYP
 import static org.bf2.cos.fleetshard.operator.camel.CamelConstants.CONNECTOR_TYPE_SOURCE;
 import static org.bf2.cos.fleetshard.operator.camel.CamelConstants.ERROR_HANDLER_DEAD_LETTER_CHANNEL_KAMELET;
 import static org.bf2.cos.fleetshard.operator.camel.CamelConstants.ERROR_HANDLER_DEAD_LETTER_CHANNEL_KAMELET_ID;
-import static org.bf2.cos.fleetshard.operator.camel.CamelConstants.ERROR_HANDLER_DEAD_LETTER_CHANNEL_TYPE;
 import static org.bf2.cos.fleetshard.operator.camel.CamelConstants.ERROR_HANDLER_LOG_TYPE;
+import static org.bf2.cos.fleetshard.operator.camel.CamelConstants.ERROR_HANDLER_SINK_CHANNEL_TYPE;
 import static org.bf2.cos.fleetshard.operator.camel.CamelConstants.ERROR_HANDLER_STOP_URI;
 import static org.bf2.cos.fleetshard.support.json.JacksonUtil.iterator;
 
@@ -464,7 +464,7 @@ public final class CamelOperandSupport {
 
     public static ObjectNode createStopErrorHandler() {
         var errorHandler = Serialization.jsonMapper().createObjectNode();
-        var dlq = errorHandler.putObject(ERROR_HANDLER_DEAD_LETTER_CHANNEL_TYPE);
+        var dlq = errorHandler.putObject(ERROR_HANDLER_SINK_CHANNEL_TYPE);
         var endpoint = dlq.putObject("endpoint");
         endpoint.put("uri", ERROR_HANDLER_STOP_URI);
         return errorHandler;
@@ -472,7 +472,7 @@ public final class CamelOperandSupport {
 
     public static ObjectNode createDeadLetterQueueErrorHandler() {
         var errorHandler = Serialization.jsonMapper().createObjectNode();
-        var dlq = errorHandler.putObject(ERROR_HANDLER_DEAD_LETTER_CHANNEL_TYPE);
+        var dlq = errorHandler.putObject(ERROR_HANDLER_SINK_CHANNEL_TYPE);
         var endpoint = dlq.putObject("endpoint");
 
         endpoint.put(

--- a/cos-fleetshard-operator-camel/src/test/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandControllerTest.java
+++ b/cos-fleetshard-operator-camel/src/test/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandControllerTest.java
@@ -130,7 +130,7 @@ public final class CamelOperandControllerTest {
                         .withPrefix("aws")
                         .build())
                     .withKafka(new EndpointKameletBuilder()
-                        .withName("managed-kafka-sink")
+                        .withName("cos-kafka-sink")
                         .withPrefix("kafka")
                         .build())
                     .addToProcessors("insert_field", "insert-field-action")
@@ -169,7 +169,7 @@ public final class CamelOperandControllerTest {
                     assertThat(binding.getSpec().getSink().getRef())
                         .hasFieldOrPropertyWithValue("apiVersion", Kamelet.RESOURCE_API_VERSION)
                         .hasFieldOrPropertyWithValue("kind", Kamelet.RESOURCE_KIND)
-                        .hasFieldOrPropertyWithValue("name", "managed-kafka-sink");
+                        .hasFieldOrPropertyWithValue("name", "cos-kafka-sink");
 
                     assertThat(binding.getSpec().getSteps()).element(0).satisfies(step -> {
                         assertThat(step.getRef())
@@ -208,10 +208,10 @@ public final class CamelOperandControllerTest {
                 byte[] decoded = Base64.getDecoder().decode(encoded);
 
                 assertThat(new String(decoded))
-                    .contains("camel.kamelet.managed-kafka-sink.topic=kafka-foo")
-                    .contains("camel.kamelet.managed-kafka-sink.bootstrapServers=kafka.acme.com:2181")
-                    .contains("camel.kamelet.managed-kafka-sink.user=kcid")
-                    .contains("camel.kamelet.managed-kafka-sink.password=kcs")
+                    .contains("camel.kamelet.cos-kafka-sink.topic=kafka-foo")
+                    .contains("camel.kamelet.cos-kafka-sink.bootstrapServers=kafka.acme.com:2181")
+                    .contains("camel.kamelet.cos-kafka-sink.user=kcid")
+                    .contains("camel.kamelet.cos-kafka-sink.password=kcs")
                     .contains("camel.kamelet.aws-kinesis-source.bar=bar")
                     .contains("camel.kamelet.aws-kinesis-source.foo=aws-foo")
                     .contains("camel.kamelet.aws-kinesis-source.fooBar=aws-foo-bar")
@@ -267,7 +267,7 @@ public final class CamelOperandControllerTest {
                         .withPrefix("aws")
                         .build())
                     .withKafka(new EndpointKameletBuilder()
-                        .withName("managed-kafka-sink")
+                        .withName("cos-kafka-sink")
                         .withPrefix("kafka")
                         .build())
                     .build())
@@ -300,7 +300,7 @@ public final class CamelOperandControllerTest {
                     assertThat(binding.getSpec().getSink().getRef())
                         .hasFieldOrPropertyWithValue("apiVersion", Kamelet.RESOURCE_API_VERSION)
                         .hasFieldOrPropertyWithValue("kind", Kamelet.RESOURCE_KIND)
-                        .hasFieldOrPropertyWithValue("name", "managed-kafka-sink");
+                        .hasFieldOrPropertyWithValue("name", "cos-kafka-sink");
                 });
             });
     }
@@ -388,9 +388,9 @@ public final class CamelOperandControllerTest {
                 assertThat(resource).isInstanceOfSatisfying(KameletBinding.class, binding -> {
 
                     assertThatObject(binding.getSpec().getErrorHandler())
-                        .extracting(h -> h.at("/dead-letter-channel/endpoint/uri"))
+                        .extracting(h -> h.at("/sink/endpoint/uri"))
                         .extracting(JsonNode::asText)
-                        .isEqualTo("kamelet://managed-kafka-sink/error");
+                        .isEqualTo("kamelet://cos-kafka-sink/error");
                 });
             });
 
@@ -406,10 +406,10 @@ public final class CamelOperandControllerTest {
                 byte[] decoded = Base64.getDecoder().decode(encoded);
 
                 assertThat(new String(decoded))
-                    .contains("camel.kamelet.managed-kafka-sink.error.topic=dlq")
-                    .contains("camel.kamelet.managed-kafka-sink.error.bootstrapServers=kafka.acme.com:2181")
-                    .contains("camel.kamelet.managed-kafka-sink.error.user=kcid")
-                    .contains("camel.kamelet.managed-kafka-sink.error.password=kcs");
+                    .contains("camel.kamelet.cos-kafka-sink.error.topic=dlq")
+                    .contains("camel.kamelet.cos-kafka-sink.error.bootstrapServers=kafka.acme.com:2181")
+                    .contains("camel.kamelet.cos-kafka-sink.error.user=kcid")
+                    .contains("camel.kamelet.cos-kafka-sink.error.password=kcs");
             });
     }
 
@@ -427,7 +427,7 @@ public final class CamelOperandControllerTest {
                 assertThat(resource).isInstanceOfSatisfying(KameletBinding.class, binding -> {
 
                     assertThatObject(binding.getSpec().getErrorHandler())
-                        .extracting(h -> h.at("/dead-letter-channel/endpoint/uri"))
+                        .extracting(h -> h.at("/sink/endpoint/uri"))
                         .extracting(JsonNode::asText)
                         .isEqualTo("controlbus:route?routeId=current&action=stop");
                 });
@@ -481,7 +481,7 @@ public final class CamelOperandControllerTest {
                         .withPrefix("aws")
                         .build())
                     .withKafka(new EndpointKameletBuilder()
-                        .withName("managed-kafka-sink")
+                        .withName("cos-kafka-sink")
                         .withPrefix("kafka")
                         .build())
                     .build())


### PR DESCRIPTION
Contains modifications to apply the selected error handling strategy,
generating the necessary kameletbinding configurations as of Camel K 1.8.
Also impacts MGDCTRS-329 as connector will fail when stopped by the
error handler.