### PR TITLE
MGDCTRS-475 Add `data_shape` handling to support "JSON without schema", "JSON" (with Schema Registry using Apicurio) and AVRO (using Apicurio)

### DIFF
--- a/cos-fleet-manager-api/src/openapi/specs/connector_mgmt.yaml
+++ b/cos-fleet-manager-api/src/openapi/specs/connector_mgmt.yaml
@@ -1286,12 +1286,12 @@ components:
           id: "9bsv0s6brfr002pfnkh0"
           client_id: "srvc-acct-162ef2d8-0209-4117-8462-df63c2025c26"
           client_secret: "b144d991-08eb-4472-8ec1-eb034c69231b"
-          url: "foo-9bsv0s6brfr002pfnkh0.kas.acme.com:443"
+          url: "https://bu98.serviceregistry.rhcloud.com/t/51eba005-daft-punk-afe1-b2178bcb523d/apis/registry/v2"
         schema_registry:
           id: "9bsv0s0k8lng031se9q0"
           client_id: "srvc-acct-e025265e-a88a-44fb-8450-ed010eb6bc5c"
           client_secret: "dc5a8298-bed7-422e-8947-f6fda69292ff"
-          url: "bar-9bsv0s2mfca002t9q7sg.srs.acme.com:443"
+          url: "https://bu98.serviceregistry.rhcloud.com/t/51eba005-daft-punk-afe1-b2178bcb523d/apis/registry/v2"
         channel: stable
         connector_type_id: "log_sink_0.1"
         connector:

--- a/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandController.java
+++ b/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandController.java
@@ -62,13 +62,13 @@ import static org.bf2.cos.fleetshard.operator.camel.CamelOperandSupport.lookupBi
 import static org.bf2.cos.fleetshard.support.CollectionUtils.asBytesBase64;
 
 @Singleton
-public class CamelOperandController extends AbstractOperandController<CamelShardMetadata, ObjectNode> {
+public class CamelOperandController extends AbstractOperandController<CamelShardMetadata, ObjectNode, ObjectNode> {
     private static final Logger LOGGER = LoggerFactory.getLogger(CamelOperandController.class);
 
     private final CamelOperandConfiguration configuration;
 
     public CamelOperandController(KubernetesClient kubernetesClient, CamelOperandConfiguration configuration) {
-        super(kubernetesClient, CamelShardMetadata.class, ObjectNode.class);
+        super(kubernetesClient, CamelShardMetadata.class, ObjectNode.class, ObjectNode.class);
 
         this.configuration = configuration;
     }
@@ -82,7 +82,7 @@ public class CamelOperandController extends AbstractOperandController<CamelShard
     protected List<HasMetadata> doReify(
         ManagedConnector connector,
         CamelShardMetadata shardMetadata,
-        ConnectorConfiguration<ObjectNode> connectorConfiguration,
+        ConnectorConfiguration<ObjectNode, ObjectNode> connectorConfiguration,
         ServiceAccountSpec serviceAccountSpec) {
 
         final Map<String, String> properties = createSecretsData(

--- a/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandSupport.java
+++ b/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandSupport.java
@@ -131,7 +131,7 @@ public final class CamelOperandSupport {
 
     public static List<ProcessorKamelet> createSteps(
         ManagedConnector connector,
-        ConnectorConfiguration<ObjectNode> connectorConfiguration,
+        ConnectorConfiguration<ObjectNode, ObjectNode> connectorConfiguration,
         CamelShardMetadata shardMetadata,
         Map<String, String> props) {
 
@@ -304,7 +304,7 @@ public final class CamelOperandSupport {
     public static Map<String, String> createSecretsData(
         ManagedConnector connector,
         CamelShardMetadata shardMetadata,
-        ConnectorConfiguration<ObjectNode> connectorConfiguration,
+        ConnectorConfiguration<ObjectNode, ObjectNode> connectorConfiguration,
         ServiceAccountSpec serviceAccountSpec,
         CamelOperandConfiguration cfg,
         Map<String, String> props) {

--- a/cos-fleetshard-operator-camel/src/test/groovy/org/bf2/cos/fleetshard/operator/camel/support/BaseSpec.groovy
+++ b/cos-fleetshard-operator-camel/src/test/groovy/org/bf2/cos/fleetshard/operator/camel/support/BaseSpec.groovy
@@ -87,7 +87,7 @@ class BaseSpec extends Specification {
 
         CONTROLLER.doReify(
                 connector, meta,
-                new ConnectorConfiguration<ObjectNode>(conf, ObjectNode.class),
+                new ConnectorConfiguration<ObjectNode, ObjectNode>(conf, ObjectNode.class, ObjectNode.class),
                 serviceAccount)
     }
 

--- a/cos-fleetshard-operator-debezium-it/src/test/java/org/bf2/cos/fleetshard/operator/it/debezium/DebeziumConnectorReifyAvroTest.java
+++ b/cos-fleetshard-operator-debezium-it/src/test/java/org/bf2/cos/fleetshard/operator/it/debezium/DebeziumConnectorReifyAvroTest.java
@@ -1,0 +1,32 @@
+package org.bf2.cos.fleetshard.operator.it.debezium;
+
+import java.util.Map;
+
+import io.quarkiverse.cucumber.CucumberOptions;
+import io.quarkiverse.cucumber.CucumberQuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+import static org.bf2.cos.fleetshard.support.resources.Resources.uid;
+
+@CucumberOptions(
+    features = {
+        "classpath:DebeziumConnectorReifyAvro.feature"
+    },
+    glue = {
+        "org.bf2.cos.fleetshard.it.cucumber",
+        "org.bf2.cos.fleetshard.operator.it.debezium.glues"
+    })
+@TestProfile(DebeziumConnectorReifyAvroTest.Profile.class)
+public class DebeziumConnectorReifyAvroTest extends CucumberQuarkusTest {
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            final String ns = "cos-debezium-" + uid();
+
+            return Map.of(
+                "cos.connectors.namespace", ns,
+                "cos.operators.namespace", ns);
+        }
+    }
+}

--- a/cos-fleetshard-operator-debezium-it/src/test/java/org/bf2/cos/fleetshard/operator/it/debezium/DebeziumConnectorReifyJsonWithSchemaTest.java
+++ b/cos-fleetshard-operator-debezium-it/src/test/java/org/bf2/cos/fleetshard/operator/it/debezium/DebeziumConnectorReifyJsonWithSchemaTest.java
@@ -1,0 +1,32 @@
+package org.bf2.cos.fleetshard.operator.it.debezium;
+
+import java.util.Map;
+
+import io.quarkiverse.cucumber.CucumberOptions;
+import io.quarkiverse.cucumber.CucumberQuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+import static org.bf2.cos.fleetshard.support.resources.Resources.uid;
+
+@CucumberOptions(
+    features = {
+        "classpath:DebeziumConnectorReifyJsonWithSchema.feature"
+    },
+    glue = {
+        "org.bf2.cos.fleetshard.it.cucumber",
+        "org.bf2.cos.fleetshard.operator.it.debezium.glues"
+    })
+@TestProfile(DebeziumConnectorReifyJsonWithSchemaTest.Profile.class)
+public class DebeziumConnectorReifyJsonWithSchemaTest extends CucumberQuarkusTest {
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            final String ns = "cos-debezium-" + uid();
+
+            return Map.of(
+                "cos.connectors.namespace", ns,
+                "cos.operators.namespace", ns);
+        }
+    }
+}

--- a/cos-fleetshard-operator-debezium-it/src/test/java/org/bf2/cos/fleetshard/operator/it/debezium/DebeziumConnectorReifySchemalessJsonTest.java
+++ b/cos-fleetshard-operator-debezium-it/src/test/java/org/bf2/cos/fleetshard/operator/it/debezium/DebeziumConnectorReifySchemalessJsonTest.java
@@ -11,14 +11,14 @@ import static org.bf2.cos.fleetshard.support.resources.Resources.uid;
 
 @CucumberOptions(
     features = {
-        "classpath:DebeziumConnectorReify.feature"
+        "classpath:DebeziumConnectorReifySchemalessJson.feature"
     },
     glue = {
         "org.bf2.cos.fleetshard.it.cucumber",
         "org.bf2.cos.fleetshard.operator.it.debezium.glues"
     })
-@TestProfile(DebeziumConnectorReifyTest.Profile.class)
-public class DebeziumConnectorReifyTest extends CucumberQuarkusTest {
+@TestProfile(DebeziumConnectorReifySchemalessJsonTest.Profile.class)
+public class DebeziumConnectorReifySchemalessJsonTest extends CucumberQuarkusTest {
     public static class Profile implements QuarkusTestProfile {
         @Override
         public Map<String, String> getConfigOverrides() {

--- a/cos-fleetshard-operator-debezium-it/src/test/java/org/bf2/cos/fleetshard/operator/it/debezium/glues/DebeziumConnectorSteps.java
+++ b/cos-fleetshard-operator-debezium-it/src/test/java/org/bf2/cos/fleetshard/operator/it/debezium/glues/DebeziumConnectorSteps.java
@@ -3,6 +3,8 @@ package org.bf2.cos.fleetshard.operator.it.debezium.glues;
 import org.bf2.cos.fleetshard.it.cucumber.support.StepsSupport;
 import org.bf2.cos.fleetshard.support.resources.Secrets;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import io.cucumber.java.ParameterType;
 import io.cucumber.java.en.And;
 import io.fabric8.kubernetes.client.utils.Serialization;
@@ -13,9 +15,7 @@ public class DebeziumConnectorSteps extends StepsSupport {
         return Boolean.valueOf(value);
     }
 
-    @And("with sample debezium connector")
-    public void with_sample_debezium_connector() {
-
+    private ObjectNode baseConfig() {
         var connector = Serialization.jsonMapper().createObjectNode();
         connector.put("database.dbname", "postgres");
         connector.put("database.hostname", "debezium-postgres");
@@ -26,14 +26,25 @@ public class DebeziumConnectorSteps extends StepsSupport {
         connector.put("slot.drop.on.stop", "true");
         connector.put("slot.name", "cos_dbz_pg");
         connector.put("table.include.list", "inventory.customers");
-        connector.put("tasks.max", "1");
+        return connector;
+    }
+
+    @And("with a simple Debezium connector")
+    public void with_simple_debezium_connector() {
+        with_debezium_connector_using_datashape("JSON without schema");
+    }
+
+    @And("with Debezium connector using {string} datashape")
+    public void with_debezium_connector_using_datashape(String dataShape) {
+        var connector = baseConfig();
+        connector.with("data_shape").put("key", dataShape).put("value", dataShape);
+        Secrets.set(ctx.secret(), Secrets.SECRET_ENTRY_CONNECTOR, connector);
 
         var meta = Serialization.jsonMapper().createObjectNode();
-        meta.put("container_image", "quay.io/asansari/debezium-connector-postgres:1.5.3.Final");
+        meta.put("container_image",
+            "quay.io/rhoas/cos-connector-debezium-postgres@sha256:b67d0ef4d4638bd5b6e71e2ccc30d5f7d5f74738db94dae53504077de7df5cff");
         meta.put("connector_class", "io.debezium.connector.postgresql.PostgresConnector");
         meta.put("connector_type", "source");
-
-        Secrets.set(ctx.secret(), Secrets.SECRET_ENTRY_CONNECTOR, connector);
         Secrets.set(ctx.secret(), Secrets.SECRET_ENTRY_META, meta);
     }
 }

--- a/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorEvents.feature
+++ b/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorEvents.feature
@@ -1,4 +1,4 @@
-Feature: Camel Connector Status
+Feature: Debezium Connector Status
 
   Background:
     Given Await configuration
@@ -8,13 +8,13 @@ Feature: Camel Connector Status
 
   Scenario: kctr becomes ready
     Given a Connector with:
-      | connector.type.id           | debezium-postgres-1.5.0.Final    |
+      | connector.type.id           | debezium-postgres-1.9.0.Alpha2    |
       | desired.state               | ready                            |
       | kafka.bootstrap             | kafka.acme.com:443               |
       | operator.id                 | cos-fleetshard-operator-debezium |
       | operator.type               | debezium-connector-operator      |
       | operator.version            | [1.0.0,2.0.0)                    |
-    And with sample debezium connector
+    And with a simple Debezium connector
 
     When deploy
     Then the connector exists

--- a/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorLifecycleDelete.feature
+++ b/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorLifecycleDelete.feature
@@ -1,4 +1,4 @@
-Feature: Camel Connector Lifecycle
+Feature: Debezium Connector Lifecycle
 
   Background:
     Given Await configuration
@@ -8,13 +8,13 @@ Feature: Camel Connector Lifecycle
 
   Scenario: delete
     Given a Connector with:
-      | connector.type.id           | debezium-postgres-1.5.0.Final    |
+      | connector.type.id           | debezium-postgres-1.9.0.Alpha2    |
       | desired.state               | ready                            |
       | kafka.bootstrap             | kafka.acme.com:443               |
       | operator.id                 | cos-fleetshard-operator-debezium |
       | operator.type               | debezium-connector-operator      |
       | operator.version            | [1.0.0,2.0.0)                    |
-    And with sample debezium connector
+    And with a simple Debezium connector
 
     When deploy
     Then the connector exists

--- a/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorLifecycleStop.feature
+++ b/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorLifecycleStop.feature
@@ -1,4 +1,4 @@
-Feature: Camel Connector Lifecycle
+Feature: Debezium Connector Lifecycle
 
   Background:
     Given Await configuration
@@ -8,13 +8,13 @@ Feature: Camel Connector Lifecycle
 
   Scenario: stop
     Given a Connector with:
-      | connector.type.id           | debezium-postgres-1.5.0.Final    |
+      | connector.type.id           | debezium-postgres-1.9.0.Alpha2    |
       | desired.state               | ready                            |
       | kafka.bootstrap             | kafka.acme.com:443               |
       | operator.id                 | cos-fleetshard-operator-debezium |
       | operator.type               | debezium-connector-operator      |
       | operator.version            | [1.0.0,2.0.0)                    |
-    And with sample debezium connector
+    And with a simple Debezium connector
 
     When deploy
     Then the connector exists

--- a/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorMetricsDelete.feature
+++ b/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorMetricsDelete.feature
@@ -1,4 +1,4 @@
-Feature: Camel Connector Metrics
+Feature: Debezium Connector Metrics
 
   Background:
     Given Await configuration
@@ -8,13 +8,13 @@ Feature: Camel Connector Metrics
 
   Scenario: delete
     Given a Connector with:
-      | connector.type.id           | debezium-postgres-1.5.0.Final    |
+      | connector.type.id           | debezium-postgres-1.9.0.Alpha2    |
       | desired.state               | ready                            |
       | kafka.bootstrap             | kafka.acme.com:443               |
       | operator.id                 | cos-fleetshard-operator-debezium |
       | operator.type               | debezium-connector-operator      |
       | operator.version            | [1.0.0,2.0.0)                    |
-    And with sample debezium connector
+    And with a simple Debezium connector
 
     When deploy
     Then the connector exists

--- a/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorMetricsDeploy.feature
+++ b/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorMetricsDeploy.feature
@@ -1,4 +1,4 @@
-Feature: Camel Connector Metrics
+Feature: Debezium Connector Metrics
 
   Background:
     Given Await configuration
@@ -8,13 +8,13 @@ Feature: Camel Connector Metrics
 
   Scenario: deploy
     Given a Connector with:
-      | connector.type.id           | debezium-postgres-1.5.0.Final    |
+      | connector.type.id           | debezium-postgres-1.9.0.Alpha2    |
       | desired.state               | ready                            |
       | kafka.bootstrap             | kafka.acme.com:443               |
       | operator.id                 | cos-fleetshard-operator-debezium |
       | operator.type               | debezium-connector-operator      |
       | operator.version            | [1.0.0,2.0.0)                    |
-    And with sample debezium connector
+    And with a simple Debezium connector
 
     When deploy
     Then the connector exists

--- a/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorMetricsStop.feature
+++ b/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorMetricsStop.feature
@@ -1,4 +1,4 @@
-Feature: Camel Connector Metrics
+Feature: Debezium Connector Metrics
 
   Background:
     Given Await configuration
@@ -8,13 +8,13 @@ Feature: Camel Connector Metrics
 
   Scenario: stop
     Given a Connector with:
-      | connector.type.id           | debezium-postgres-1.5.0.Final    |
+      | connector.type.id           | debezium-postgres-1.9.0.Alpha2    |
       | desired.state               | ready                            |
       | kafka.bootstrap             | kafka.acme.com:443               |
       | operator.id                 | cos-fleetshard-operator-debezium |
       | operator.type               | debezium-connector-operator      |
       | operator.version            | [1.0.0,2.0.0)                    |
-    And with sample debezium connector
+    And with a simple Debezium connector
 
     When deploy
     Then the connector exists

--- a/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorReifyJsonWithSchema.feature
+++ b/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorReifyJsonWithSchema.feature
@@ -1,0 +1,84 @@
+Feature: Debezium Connector Reify
+
+  Background:
+    Given Await configuration
+      | atMost       | 30000   |
+      | pollDelay    | 100     |
+      | pollInterval | 500     |
+
+  Scenario: reify
+    Given a Connector with:
+      | connector.type.id           | debezium-postgres-1.9.0.Alpha2    |
+      | desired.state               | ready                            |
+      | kafka.bootstrap             | kafka.acme.com:443               |
+      | operator.id                 | cos-fleetshard-operator-debezium |
+      | operator.type               | debezium-connector-operator      |
+      | operator.version            | [1.0.0,2.0.0)                    |
+    And with Debezium connector using "JSON" datashape
+
+    When deploy
+    Then the connector exists
+     And the connector secret exists
+     And the connector is in phase "Monitor"
+
+    Then the kc exists
+     And the kc has labels containing:
+       | cos.bf2.org/cluster.id           | ${cos.cluster.id}             |
+       | cos.bf2.org/connector.id         | ${cos.connector.id}           |
+       | cos.bf2.org/deployment.id        | ${cos.deployment.id}          |
+       | app.kubernetes.io/managed-by     | ${cos.operator.id}            |
+       | app.kubernetes.io/created-by     | ${cos.operator.id}            |
+       | app.kubernetes.io/component      | connector                     |
+       | app.kubernetes.io/version        | 1                             |
+       | app.kubernetes.io/part-of        | ${cos.cluster.id}             |
+       | app.kubernetes.io/name           | ${cos.connector.id}           |
+       | app.kubernetes.io/instance       | ${cos.deployment.id}          |
+
+     And the kc has an entry at path "$.metadata.ownerReferences[0].apiVersion" with value "cos.bf2.org/v1alpha1"
+     And the kc has an entry at path "$.metadata.ownerReferences[0].kind" with value "ManagedConnector"
+     And the kc has an entry at path "$.spec.authentication.passwordSecret.secretName" with value "${cos.managed.connector.name}-config"
+     And the kc has an entry at path "$.spec.authentication.passwordSecret.password" with value "_kafka.client.secret"
+     And the kc has an entry at path "$.spec.image" with value "quay.io/rhoas/cos-connector-debezium-postgres@sha256:b67d0ef4d4638bd5b6e71e2ccc30d5f7d5f74738db94dae53504077de7df5cff"
+     And the kc has config containing:
+       | config.providers                  | file,dir                             |
+       | config.storage.replication.factor | -1                                   |
+       | config.storage.topic              | ${cos.managed.connector.name}-config |
+       | offset.storage.topic              | ${cos.managed.connector.name}-offset |
+       | status.storage.topic              | ${cos.managed.connector.name}-status |
+       | group.id                          | ${cos.managed.connector.name}        |
+       | connector.secret.name             | ${cos.managed.connector.name}-config |
+       | connector.secret.checksum         | ${cos.ignore}                        |
+       | key.converter                     | io.apicurio.registry.utils.converter.ExtJsonConverter                                                             |
+       | value.converter                   | io.apicurio.registry.utils.converter.ExtJsonConverter                                                             |
+       | key.converter.apicurio.registry.url           |  https://bu98.serviceregistry.rhcloud.com/t/51eba005-daft-punk-afe1-b2178bcb523d/apis/registry/v2          |
+       | value.converter.apicurio.registry.url         |  https://bu98.serviceregistry.rhcloud.com/t/51eba005-daft-punk-afe1-b2178bcb523d/apis/registry/v2          |
+       | key.converter.apicurio.auth.client.id         |  ${kafka.client.id}      |
+       | value.converter.apicurio.auth.client.id       |  ${kafka.client.id}      |
+       | key.converter.apicurio.auth.client.secret     |  ${dir:/opt/kafka/external-configuration/connector-configuration:_kafka.client.secret}                    |
+       | value.converter.apicurio.auth.client.secret   |  ${dir:/opt/kafka/external-configuration/connector-configuration:_kafka.client.secret}                    |
+
+
+    Then the kctr exists
+     And the kctr has labels containing:
+       | cos.bf2.org/cluster.id           | ${cos.cluster.id}             |
+       | cos.bf2.org/connector.id         | ${cos.connector.id}           |
+       | cos.bf2.org/deployment.id        | ${cos.deployment.id}          |
+       | strimzi.io/cluster               | ${cos.managed.connector.name} |
+       | app.kubernetes.io/managed-by     | ${cos.operator.id}            |
+       | app.kubernetes.io/created-by     | ${cos.operator.id}            |
+       | app.kubernetes.io/component      | connector                     |
+       | app.kubernetes.io/version        | 1                             |
+       | app.kubernetes.io/part-of        | ${cos.cluster.id}             |
+       | app.kubernetes.io/name           | ${cos.connector.id}           |
+       | app.kubernetes.io/instance       | ${cos.deployment.id}          |
+
+     And the kctr has an entry at path "$.metadata.ownerReferences[0].apiVersion" with value "cos.bf2.org/v1alpha1"
+     And the kctr has an entry at path "$.metadata.ownerReferences[0].kind" with value "ManagedConnector"
+     And the kctr has an entry at path "$.spec.pause" with value false
+     And the kctr has an entry at path "$.spec.tasksMax" with value 1
+     And the kctr has an entry at path "$.spec.class" with value "io.debezium.connector.postgresql.PostgresConnector"
+     And the kctr has config containing:
+       | database.password                 | ${file:/opt/kafka/external-configuration/connector-configuration/debezium-connector.properties:database.password} |
+
+
+

--- a/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorReifySchemalessJson.feature
+++ b/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorReifySchemalessJson.feature
@@ -1,0 +1,79 @@
+Feature: Debezium Connector Reify
+
+  Background:
+    Given Await configuration
+      | atMost       | 30000   |
+      | pollDelay    | 100     |
+      | pollInterval | 500     |
+
+  Scenario: reify
+    Given a Connector with:
+      | connector.type.id           | debezium-postgres-1.9.0.Alpha2    |
+      | desired.state               | ready                            |
+      | kafka.bootstrap             | kafka.acme.com:443               |
+      | operator.id                 | cos-fleetshard-operator-debezium |
+      | operator.type               | debezium-connector-operator      |
+      | operator.version            | [1.0.0,2.0.0)                    |
+    And with Debezium connector using "JSON without schema" datashape
+
+    When deploy
+    Then the connector exists
+     And the connector secret exists
+     And the connector is in phase "Monitor"
+
+    Then the kc exists
+     And the kc has labels containing:
+       | cos.bf2.org/cluster.id           | ${cos.cluster.id}             |
+       | cos.bf2.org/connector.id         | ${cos.connector.id}           |
+       | cos.bf2.org/deployment.id        | ${cos.deployment.id}          |
+       | app.kubernetes.io/managed-by     | ${cos.operator.id}            |
+       | app.kubernetes.io/created-by     | ${cos.operator.id}            |
+       | app.kubernetes.io/component      | connector                     |
+       | app.kubernetes.io/version        | 1                             |
+       | app.kubernetes.io/part-of        | ${cos.cluster.id}             |
+       | app.kubernetes.io/name           | ${cos.connector.id}           |
+       | app.kubernetes.io/instance       | ${cos.deployment.id}          |
+
+     And the kc has an entry at path "$.metadata.ownerReferences[0].apiVersion" with value "cos.bf2.org/v1alpha1"
+     And the kc has an entry at path "$.metadata.ownerReferences[0].kind" with value "ManagedConnector"
+     And the kc has an entry at path "$.spec.authentication.passwordSecret.secretName" with value "${cos.managed.connector.name}-config"
+     And the kc has an entry at path "$.spec.authentication.passwordSecret.password" with value "_kafka.client.secret"
+     And the kc has an entry at path "$.spec.image" with value "quay.io/rhoas/cos-connector-debezium-postgres@sha256:b67d0ef4d4638bd5b6e71e2ccc30d5f7d5f74738db94dae53504077de7df5cff"
+     And the kc has config containing:
+       | config.providers                  | file,dir                             |
+       | config.storage.replication.factor | -1                                   |
+       | config.storage.topic              | ${cos.managed.connector.name}-config |
+       | offset.storage.topic              | ${cos.managed.connector.name}-offset |
+       | status.storage.topic              | ${cos.managed.connector.name}-status |
+       | group.id                          | ${cos.managed.connector.name}        |
+       | connector.secret.name             | ${cos.managed.connector.name}-config |
+       | connector.secret.checksum         | ${cos.ignore}                        |
+       | key.converter                     | org.apache.kafka.connect.json.JsonConverter                                                                       |
+       | value.converter                   | org.apache.kafka.connect.json.JsonConverter                                                                       |
+       | key.converter.schemas.enable      | false                                |
+       | value.converter.schemas.enable    | false                                |
+
+    Then the kctr exists
+     And the kctr has labels containing:
+       | cos.bf2.org/cluster.id           | ${cos.cluster.id}             |
+       | cos.bf2.org/connector.id         | ${cos.connector.id}           |
+       | cos.bf2.org/deployment.id        | ${cos.deployment.id}          |
+       | strimzi.io/cluster               | ${cos.managed.connector.name} |
+       | app.kubernetes.io/managed-by     | ${cos.operator.id}            |
+       | app.kubernetes.io/created-by     | ${cos.operator.id}            |
+       | app.kubernetes.io/component      | connector                     |
+       | app.kubernetes.io/version        | 1                             |
+       | app.kubernetes.io/part-of        | ${cos.cluster.id}             |
+       | app.kubernetes.io/name           | ${cos.connector.id}           |
+       | app.kubernetes.io/instance       | ${cos.deployment.id}          |
+
+     And the kctr has an entry at path "$.metadata.ownerReferences[0].apiVersion" with value "cos.bf2.org/v1alpha1"
+     And the kctr has an entry at path "$.metadata.ownerReferences[0].kind" with value "ManagedConnector"
+     And the kctr has an entry at path "$.spec.pause" with value false
+     And the kctr has an entry at path "$.spec.tasksMax" with value 1
+     And the kctr has an entry at path "$.spec.class" with value "io.debezium.connector.postgresql.PostgresConnector"
+     And the kctr has config containing:
+       | database.password                 | ${file:/opt/kafka/external-configuration/connector-configuration/debezium-connector.properties:database.password} |
+
+
+

--- a/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorReifyWithExternalConfig.feature
+++ b/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorReifyWithExternalConfig.feature
@@ -1,4 +1,4 @@
-Feature: Camel Connector Reify
+Feature: Debezium Connector Reify
 
   Background:
     Given Await configuration
@@ -8,13 +8,13 @@ Feature: Camel Connector Reify
 
   Scenario: reify
     Given a Connector with:
-      | connector.type.id           | debezium-postgres-1.5.0.Final    |
+      | connector.type.id           | debezium-postgres-1.9.0.Alpha2    |
       | desired.state               | ready                            |
       | kafka.bootstrap             | kafka.acme.com:443               |
       | operator.id                 | cos-fleetshard-operator-debezium |
       | operator.type               | debezium-connector-operator      |
       | operator.version            | [1.0.0,2.0.0)                    |
-    And with sample debezium connector
+    And with a simple Debezium connector
 
     When deploy
     Then the connector exists
@@ -31,9 +31,9 @@ Feature: Camel Connector Reify
     And the kc has an entry at path "$.metadata.ownerReferences[0].kind" with value "ManagedConnector"
     And the kc has an entry at path "$.spec.authentication.passwordSecret.secretName" with value "${cos.managed.connector.name}-config"
     And the kc has an entry at path "$.spec.authentication.passwordSecret.password" with value "_kafka.client.secret"
-    And the kc has an entry at path "$.spec.image" with value "quay.io/asansari/debezium-connector-postgres:1.5.3.Final"
+    And the kc has an entry at path "$.spec.image" with value "quay.io/rhoas/cos-connector-debezium-postgres@sha256:b67d0ef4d4638bd5b6e71e2ccc30d5f7d5f74738db94dae53504077de7df5cff"
     And the kc has config containing:
-      | config.providers                  | file                                 |
+      | config.providers                  | file,dir                             |
       | config.storage.replication.factor | 3                                    |
       | config.storage.topic              | ${cos.managed.connector.name}-config |
       | offset.storage.topic              | ${cos.managed.connector.name}-offset |

--- a/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorReifyWithTargetMeta.feature
+++ b/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorReifyWithTargetMeta.feature
@@ -8,7 +8,7 @@ Feature: Debezium Connector Reify With Target Meta
 
   Scenario: reify with target meta
     Given a Connector with:
-      | connector.type.id           | debezium-postgres-1.5.0.Final    |
+      | connector.type.id           | debezium-postgres-1.9.0.Alpha2    |
       | desired.state               | ready                            |
       | kafka.bootstrap             | kafka.acme.com:443               |
       | operator.id                 | cos-fleetshard-operator-debezium |
@@ -16,7 +16,7 @@ Feature: Debezium Connector Reify With Target Meta
       | operator.version            | [1.0.0,2.0.0)                    |
     And set connector annotation "foo/barAnnotation" to "baz"
     And set connector label "foo/barLabel" to "baz"
-    And with sample debezium connector
+    And with a simple Debezium connector
 
     When deploy
     Then the connector exists

--- a/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/DebeziumConstants.java
+++ b/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/DebeziumConstants.java
@@ -34,8 +34,9 @@ public final class DebeziumConstants {
         "status.storage.replication.factor", -1,
         "key.converter.schemas.enable", true,
         "value.converter.schemas.enable", true,
-        "config.providers", "file",
-        "config.providers.file.class", "org.apache.kafka.common.config.provider.FileConfigProvider");
+        "config.providers", "file,dir",
+        "config.providers.file.class", "org.apache.kafka.common.config.provider.FileConfigProvider",
+        "config.providers.dir.class", "org.apache.kafka.common.config.provider.DirectoryConfigProvider");
 
     public static final List<ResourceDefinitionContext> RESOURCE_TYPES = List.of(
         new ResourceDefinitionContext.Builder()

--- a/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/DebeziumOperandConfiguration.java
+++ b/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/DebeziumOperandConfiguration.java
@@ -3,16 +3,9 @@ package org.bf2.cos.fleetshard.operator.debezium;
 import java.util.Map;
 
 import io.smallrye.config.ConfigMapping;
-import io.smallrye.config.WithDefault;
 
 @ConfigMapping(prefix = "cos.operator.debezium")
 public interface DebeziumOperandConfiguration {
-
-    @WithDefault("org.apache.kafka.connect.json.JsonConverter")
-    String keyConverter();
-
-    @WithDefault("org.apache.kafka.connect.json.JsonConverter")
-    String valueConverter();
 
     KafkaConnect kafkaConnect();
 

--- a/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/model/AbstractApicurioConverter.java
+++ b/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/model/AbstractApicurioConverter.java
@@ -1,0 +1,36 @@
+package org.bf2.cos.fleetshard.operator.debezium.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.bf2.cos.fleetshard.api.ManagedConnector;
+import org.bf2.cos.fleetshard.api.SchemaRegistrySpec;
+import org.bf2.cos.fleetshard.api.ServiceAccountSpec;
+import org.bf2.cos.fleetshard.operator.debezium.DebeziumConstants;
+
+public abstract class AbstractApicurioConverter implements KafkaConnectConverter {
+
+    public static final String APICURIO_AUTH_SERVICE_URL = "https://identity.api.openshift.com/auth";
+
+    @Override
+    public Map<String, String> getAdditionalConfig(ManagedConnector config, ServiceAccountSpec serviceAccountSpec) {
+        Map<String, String> additionalConfig = new HashMap<>();
+        additionalConfig.put("apicurio.auth.service.url", APICURIO_AUTH_SERVICE_URL);
+        additionalConfig.put("apicurio.auth.realm", "rhoas");
+
+        SchemaRegistrySpec schemaRegistrySpec = config.getSpec().getDeployment().getSchemaRegistry();
+        if (null == schemaRegistrySpec || null == schemaRegistrySpec.getUrl() || schemaRegistrySpec.getUrl().isBlank()) {
+            throw new RuntimeException("Can't create a schema-based connector without providing a valid 'schema_registry'");
+        }
+        String schemaRegistryURL = schemaRegistrySpec.getUrl();
+
+        additionalConfig.put("apicurio.registry.url", schemaRegistryURL);
+        additionalConfig.put("apicurio.auth.client.id", serviceAccountSpec.getClientId());
+        additionalConfig.put("apicurio.auth.client.secret",
+            "${dir:/opt/kafka/external-configuration/" + DebeziumConstants.EXTERNAL_CONFIG_DIRECTORY + ":"
+                + DebeziumConstants.KAFKA_CLIENT_SECRET_KEY + "}");
+        additionalConfig.put("apicurio.registry.auto-register", "true");
+        additionalConfig.put("apicurio.registry.find-latest", "true");
+        return additionalConfig;
+    }
+}

--- a/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/model/ApicurioAvroConverter.java
+++ b/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/model/ApicurioAvroConverter.java
@@ -1,0 +1,11 @@
+package org.bf2.cos.fleetshard.operator.debezium.model;
+
+public class ApicurioAvroConverter extends AbstractApicurioConverter implements KafkaConnectConverter {
+
+    public static final String CONVERTER_CLASS = "io.apicurio.registry.utils.converter.AvroConverter";
+
+    @Override
+    public String getConverterClass() {
+        return CONVERTER_CLASS;
+    }
+}

--- a/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/model/ApicurioJsonConverter.java
+++ b/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/model/ApicurioJsonConverter.java
@@ -1,0 +1,11 @@
+package org.bf2.cos.fleetshard.operator.debezium.model;
+
+public class ApicurioJsonConverter extends AbstractApicurioConverter implements KafkaConnectConverter {
+
+    public static final String CONVERTER_CLASS = "io.apicurio.registry.utils.converter.ExtJsonConverter";
+
+    @Override
+    public String getConverterClass() {
+        return CONVERTER_CLASS;
+    }
+}

--- a/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/model/DebeziumDataShape.java
+++ b/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/model/DebeziumDataShape.java
@@ -1,0 +1,54 @@
+package org.bf2.cos.fleetshard.operator.debezium.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DebeziumDataShape {
+
+    private String keyConverterString;
+    private String valueConverterString;
+    private KafkaConnectConverter keyConverter;
+    private KafkaConnectConverter valueConverter;
+
+    private static KafkaConnectConverter createConverter(String converterType) {
+        switch (converterType) {
+            case "JSON":
+                return new ApicurioJsonConverter();
+            case "AVRO":
+                return new ApicurioAvroConverter();
+            default:
+            case "JSON_WITHOUT_SCHEMA":
+            case "JSON without schema":
+                return new KafkaConnectJsonConverter();
+        }
+    }
+
+    @JsonProperty("key")
+    public String getKeyConverterAsString() {
+        return keyConverterString;
+    }
+
+    @JsonProperty("key")
+    public void setKeyConverter(String keyConverterString) {
+        this.keyConverterString = keyConverterString;
+        this.keyConverter = createConverter(keyConverterString);
+    }
+
+    public KafkaConnectConverter getKeyConverter() {
+        return keyConverter;
+    }
+
+    @JsonProperty("value")
+    public String getValueConverterAsString() {
+        return valueConverterString;
+    }
+
+    @JsonProperty("value")
+    public void setValueConverter(String valueConverterString) {
+        this.valueConverterString = valueConverterString;
+        this.valueConverter = createConverter(valueConverterString);
+    }
+
+    public KafkaConnectConverter getValueConverter() {
+        return valueConverter;
+    }
+}

--- a/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/model/KafkaConnectConverter.java
+++ b/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/model/KafkaConnectConverter.java
@@ -1,0 +1,13 @@
+package org.bf2.cos.fleetshard.operator.debezium.model;
+
+import java.util.Map;
+
+import org.bf2.cos.fleetshard.api.ManagedConnector;
+import org.bf2.cos.fleetshard.api.ServiceAccountSpec;
+
+interface KafkaConnectConverter {
+
+    String getConverterClass();
+
+    Map<String, String> getAdditionalConfig(ManagedConnector config, ServiceAccountSpec serviceAccountSpec);
+}

--- a/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/model/KafkaConnectJsonConverter.java
+++ b/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/model/KafkaConnectJsonConverter.java
@@ -1,0 +1,21 @@
+package org.bf2.cos.fleetshard.operator.debezium.model;
+
+import java.util.Map;
+
+import org.bf2.cos.fleetshard.api.ManagedConnector;
+import org.bf2.cos.fleetshard.api.ServiceAccountSpec;
+
+public class KafkaConnectJsonConverter implements KafkaConnectConverter {
+
+    public static final String CONVERTER_CLASS = "org.apache.kafka.connect.json.JsonConverter";
+
+    @Override
+    public String getConverterClass() {
+        return CONVERTER_CLASS;
+    }
+
+    @Override
+    public Map<String, String> getAdditionalConfig(ManagedConnector config, ServiceAccountSpec serviceAccountSpec) {
+        return Map.of("schemas.enable", "false");
+    }
+}

--- a/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/model/KeyAndValueConverters.java
+++ b/cos-fleetshard-operator-debezium/src/main/java/org/bf2/cos/fleetshard/operator/debezium/model/KeyAndValueConverters.java
@@ -1,0 +1,33 @@
+package org.bf2.cos.fleetshard.operator.debezium.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.bf2.cos.fleetshard.api.ManagedConnector;
+import org.bf2.cos.fleetshard.api.ServiceAccountSpec;
+
+public class KeyAndValueConverters {
+
+    public static final String PROPERTY_KEY_CONVERTER = "key.converter";
+    public static final String PROPERTY_VALUE_CONVERTER = "value.converter";
+
+    private static Map<String, String> prefixMapKeys(String prefix, Map<String, String> map) {
+        return map.entrySet().stream().map(property -> Map.entry(prefix + property.getKey(), property.getValue()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public static Map<String, Object> getConfig(DebeziumDataShape dataShape, ManagedConnector config,
+        ServiceAccountSpec serviceAccountSpec) {
+        var converterConfig = new HashMap<>(Map.of(
+            PROPERTY_KEY_CONVERTER, dataShape.getKeyConverter().getConverterClass(),
+            PROPERTY_VALUE_CONVERTER, dataShape.getValueConverter().getConverterClass()));
+
+        converterConfig.putAll(prefixMapKeys(PROPERTY_KEY_CONVERTER + ".",
+            dataShape.getKeyConverter().getAdditionalConfig(config, serviceAccountSpec)));
+        converterConfig.putAll(prefixMapKeys(PROPERTY_VALUE_CONVERTER + ".",
+            dataShape.getValueConverter().getAdditionalConfig(config, serviceAccountSpec)));
+
+        return new HashMap<>(converterConfig);
+    }
+}

--- a/cos-fleetshard-operator-debezium/src/test/java/org/bf2/cos/fleetshard/operator/debezium/DebeziumOperandControllerTest.java
+++ b/cos-fleetshard-operator-debezium/src/test/java/org/bf2/cos/fleetshard/operator/debezium/DebeziumOperandControllerTest.java
@@ -3,6 +3,7 @@ package org.bf2.cos.fleetshard.operator.debezium;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.bf2.cos.fleetshard.api.ConnectorStatusSpec;
@@ -13,7 +14,13 @@ import org.bf2.cos.fleetshard.api.ManagedConnectorBuilder;
 import org.bf2.cos.fleetshard.api.ManagedConnectorSpecBuilder;
 import org.bf2.cos.fleetshard.api.ServiceAccountSpecBuilder;
 import org.bf2.cos.fleetshard.operator.connector.ConnectorConfiguration;
+import org.bf2.cos.fleetshard.operator.debezium.model.AbstractApicurioConverter;
+import org.bf2.cos.fleetshard.operator.debezium.model.ApicurioAvroConverter;
+import org.bf2.cos.fleetshard.operator.debezium.model.ApicurioJsonConverter;
+import org.bf2.cos.fleetshard.operator.debezium.model.DebeziumDataShape;
+import org.bf2.cos.fleetshard.operator.debezium.model.KafkaConnectJsonConverter;
 import org.bf2.cos.fleetshard.operator.debezium.model.KafkaConnectorStatus;
+import org.bf2.cos.fleetshard.operator.debezium.model.KeyAndValueConverters;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -44,22 +51,14 @@ public class DebeziumOperandControllerTest {
     private static final String DEFAULT_CONNECTOR_IMAGE = "quay.io/cos/pg:1";
     private static final String DEFAULT_DEPLOYMENT_ID = "1";
     private static final Long DEFAULT_DEPLOYMENT_REVISION = 1L;
-    private static final String DEFAULT_KAFKA_CLIENT_ID = "kcid";
+    private static final String CLIENT_ID = "kcid";
+    private static final String CLIENT_SECRET = Base64.getEncoder().encodeToString("kcs".getBytes(StandardCharsets.UTF_8));
     private static final String DEFAULT_KAFKA_SERVER = "kafka.acme.com:2181";
     private static final String PG_CLASS = "io.debezium.connector.postgresql.PostgresConnector";
-    private static final String PG_ARTIFACT_SHA = "8b4aff3142e0340ece4586d53793bd2108d8f0fa1f87f8";
+    private static final String SCHEMA_REGISTRY_URL = "https://bu98.serviceregistry.rhcloud.com/t/51eba005-daft-punk-afe1-b2178bcb523d/apis/registry/v2";
+    private static final String SCHEMA_REGISTRY_ID = "9bsv0s0k8lng031se9q0";
 
     private static final DebeziumOperandConfiguration CONFIGURATION = new DebeziumOperandConfiguration() {
-        @Override
-        public String keyConverter() {
-            return "";
-        }
-
-        @Override
-        public String valueConverter() {
-            return "";
-        }
-
         @Override
         public KafkaConnect kafkaConnect() {
             return Map::of;
@@ -120,14 +119,7 @@ public class DebeziumOperandControllerTest {
                 && KafkaConnector.RESOURCE_KIND.equals(ctx.getKind()));
     }
 
-    @Test
-    void reify() {
-        KubernetesClient kubernetesClient = Mockito.mock(KubernetesClient.class);
-        DebeziumOperandController controller = new DebeziumOperandController(kubernetesClient, CONFIGURATION);
-
-        final String kcsB64 = Base64.getEncoder().encodeToString("kcs".getBytes(StandardCharsets.UTF_8));
-        final String pwdB64 = Base64.getEncoder().encodeToString("orderpw".getBytes(StandardCharsets.UTF_8));
-
+    private ObjectNode getSpec() {
         var spec = Serialization.jsonMapper().createObjectNode()
             .put("database.hostname", "orderdb")
             .put("database.port", "5432")
@@ -137,16 +129,35 @@ public class DebeziumOperandControllerTest {
             .put("schema.include.list", "purchaseorder")
             .put("table.include.list", "purchaseorder.outboxevent")
             .put("tombstones.on.delete", "false")
-            .put("key.converter", "org.apache.kafka.connect.storage.StringConverter")
-            .put("value.converter", "org.apache.kafka.connect.storage.StringConverter")
             .put("transforms", "saga")
             .put("transforms.saga.type", "io.debezium.transforms.outbox.EventRouter")
             .put("transforms.saga.route.topic.replacement", "${routedByValue}.request")
             .put("poll.interval.ms", "100")
             .put("consumer.interceptor.classes", "io.opentracing.contrib.kafka.TracingConsumerInterceptor")
             .put("producer.interceptor.classes", "io.opentracing.contrib.kafka.TracingProducerInterceptor");
-        spec.with("data_shape").put("key", "JSON").put("value", "JSON");
+        var pwdB64 = Base64.getEncoder().encodeToString("orderpw".getBytes(StandardCharsets.UTF_8));
         spec.with("database.password").put("kind", "base64").put("value", pwdB64);
+        return spec;
+    }
+
+    private ObjectNode addAvroToConnectorConfig(ObjectNode baseConfig) {
+        baseConfig.with("data_shape").put("key", "AVRO").put("value", "AVRO");
+        return baseConfig;
+    }
+
+    private ObjectNode addJsonWithSchemaToConnectorConfig(ObjectNode baseConfig) {
+        baseConfig.with("data_shape").put("key", "JSON").put("value", "JSON");
+        return baseConfig;
+    }
+
+    private ObjectNode addSchemalessJsonToConnectorConfig(ObjectNode baseConfig) {
+        baseConfig.with("data_shape").put("key", "JSON without schema").put("value", "JSON_WITHOUT_SCHEMA");
+        return baseConfig;
+    }
+
+    void reify(ObjectNode connectorConfig, Consumer<KafkaConnect> kafkaConnectChecks) {
+        KubernetesClient kubernetesClient = Mockito.mock(KubernetesClient.class);
+        DebeziumOperandController controller = new DebeziumOperandController(kubernetesClient, CONFIGURATION);
 
         var resources = controller.doReify(
             new ManagedConnectorBuilder()
@@ -160,6 +171,7 @@ public class DebeziumOperandControllerTest {
                         .withConnectorTypeId(DEFAULT_CONNECTOR_TYPE_ID)
                         .withSecret("secret")
                         .withKafka(new KafkaSpecBuilder().withUrl(DEFAULT_KAFKA_SERVER).build())
+                        .withNewSchemaRegistry(SCHEMA_REGISTRY_ID, SCHEMA_REGISTRY_URL)
                         .withConnectorResourceVersion(DEFAULT_CONNECTOR_REVISION)
                         .withDeploymentResourceVersion(DEFAULT_DEPLOYMENT_REVISION)
                         .withDesiredState(DESIRED_STATE_READY)
@@ -170,10 +182,11 @@ public class DebeziumOperandControllerTest {
                 .withContainerImage(DEFAULT_CONNECTOR_IMAGE)
                 .withConnectorClass(PG_CLASS)
                 .build(),
-            new ConnectorConfiguration<>(spec, ObjectNode.class),
+            new ConnectorConfiguration<>(connectorConfig, ObjectNode.class,
+                DebeziumDataShape.class),
             new ServiceAccountSpecBuilder()
-                .withClientId(DEFAULT_KAFKA_CLIENT_ID)
-                .withClientSecret(kcsB64)
+                .withClientId(CLIENT_ID)
+                .withClientSecret(CLIENT_SECRET)
                 .build());
 
         assertThat(resources)
@@ -188,20 +201,94 @@ public class DebeziumOperandControllerTest {
             .isInstanceOfSatisfying(KafkaConnect.class, kc -> {
                 assertThat(kc.getSpec().getImage()).isEqualTo(DEFAULT_CONNECTOR_IMAGE);
             });
+
         assertThat(resources)
             .filteredOn(DebeziumOperandSupport::isKafkaConnector)
             .hasSize(1)
             .first()
-            .isInstanceOfSatisfying(KafkaConnector.class, kc -> {
-                assertThat(kc.getSpec().getConfig()).containsEntry(
-                    "database.password",
-                    "${file:/opt/kafka/external-configuration/"
-                        + DebeziumConstants.EXTERNAL_CONFIG_DIRECTORY
-                        + "/"
-                        + EXTERNAL_CONFIG_FILE
-                        + ":database.password}");
-            });
+            .isInstanceOfSatisfying(KafkaConnector.class, kc -> assertThat(kc.getSpec().getConfig()).containsEntry(
+                "database.password",
+                "${file:/opt/kafka/external-configuration/"
+                    + DebeziumConstants.EXTERNAL_CONFIG_DIRECTORY
+                    + "/"
+                    + EXTERNAL_CONFIG_FILE
+                    + ":database.password}"));
 
+        assertThat(resources)
+            .filteredOn(DebeziumOperandSupport::isKafkaConnect)
+            .hasSize(1)
+            .first()
+            .isInstanceOfSatisfying(KafkaConnect.class, kafkaConnectChecks);
+    }
+
+    @Test
+    void testReifyWithSchemalessJson() {
+        this.reify(addSchemalessJsonToConnectorConfig(getSpec()),
+            kafkaConnect -> {
+                assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(KeyAndValueConverters.PROPERTY_KEY_CONVERTER,
+                    KafkaConnectJsonConverter.CONVERTER_CLASS);
+                assertThat(kafkaConnect.getSpec().getConfig())
+                    .containsEntry(KeyAndValueConverters.PROPERTY_KEY_CONVERTER + ".schemas.enable", "false");
+                assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(KeyAndValueConverters.PROPERTY_VALUE_CONVERTER,
+                    KafkaConnectJsonConverter.CONVERTER_CLASS);
+                assertThat(kafkaConnect.getSpec().getConfig())
+                    .containsEntry(KeyAndValueConverters.PROPERTY_VALUE_CONVERTER + ".schemas.enable", "false");
+            });
+    }
+
+    private Consumer<KafkaConnect> getApicurioChecks(String converterClass) {
+        return kafkaConnect -> {
+            assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(KeyAndValueConverters.PROPERTY_KEY_CONVERTER,
+                converterClass);
+            assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(KeyAndValueConverters.PROPERTY_VALUE_CONVERTER,
+                converterClass);
+            assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(
+                KeyAndValueConverters.PROPERTY_KEY_CONVERTER + ".apicurio.auth.service.url",
+                AbstractApicurioConverter.APICURIO_AUTH_SERVICE_URL);
+            assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(
+                KeyAndValueConverters.PROPERTY_VALUE_CONVERTER + ".apicurio.auth.service.url",
+                AbstractApicurioConverter.APICURIO_AUTH_SERVICE_URL);
+            assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(
+                KeyAndValueConverters.PROPERTY_KEY_CONVERTER + ".apicurio.auth.realm", "rhoas");
+            assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(
+                KeyAndValueConverters.PROPERTY_VALUE_CONVERTER + ".apicurio.auth.realm", "rhoas");
+            assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(
+                KeyAndValueConverters.PROPERTY_KEY_CONVERTER + ".apicurio.registry.url",
+                SCHEMA_REGISTRY_URL);
+            assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(
+                KeyAndValueConverters.PROPERTY_VALUE_CONVERTER + ".apicurio.registry.url",
+                SCHEMA_REGISTRY_URL);
+            assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(
+                KeyAndValueConverters.PROPERTY_KEY_CONVERTER + ".apicurio.auth.client.id",
+                CLIENT_ID);
+            assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(
+                KeyAndValueConverters.PROPERTY_VALUE_CONVERTER + ".apicurio.auth.client.id",
+                CLIENT_ID);
+            assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(
+                KeyAndValueConverters.PROPERTY_KEY_CONVERTER + ".apicurio.auth.client.secret",
+                "${dir:/opt/kafka/external-configuration/connector-configuration:_kafka.client.secret}");
+            assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(
+                KeyAndValueConverters.PROPERTY_VALUE_CONVERTER + ".apicurio.auth.client.secret",
+                "${dir:/opt/kafka/external-configuration/connector-configuration:_kafka.client.secret}");
+            assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(
+                KeyAndValueConverters.PROPERTY_KEY_CONVERTER + ".apicurio.registry.auto-register", "true");
+            assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(
+                KeyAndValueConverters.PROPERTY_VALUE_CONVERTER + ".apicurio.registry.auto-register", "true");
+            assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(
+                KeyAndValueConverters.PROPERTY_KEY_CONVERTER + ".apicurio.registry.find-latest", "true");
+            assertThat(kafkaConnect.getSpec().getConfig()).containsEntry(
+                KeyAndValueConverters.PROPERTY_VALUE_CONVERTER + ".apicurio.registry.find-latest", "true");
+        };
+    }
+
+    @Test
+    void testReifyWithAvro() {
+        this.reify(addAvroToConnectorConfig(getSpec()), getApicurioChecks(ApicurioAvroConverter.CONVERTER_CLASS));
+    }
+
+    @Test
+    void testReifyWithJsonWithSchema() {
+        this.reify(addJsonWithSchemaToConnectorConfig(getSpec()), getApicurioChecks(ApicurioJsonConverter.CONVERTER_CLASS));
     }
 
     @ParameterizedTest

--- a/cos-fleetshard-operator/src/main/java/org/bf2/cos/fleetshard/operator/connector/ConnectorConfiguration.java
+++ b/cos-fleetshard-operator/src/main/java/org/bf2/cos/fleetshard/operator/connector/ConnectorConfiguration.java
@@ -1,36 +1,32 @@
 package org.bf2.cos.fleetshard.operator.connector;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.Properties;
 import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import io.fabric8.kubernetes.client.utils.Serialization;
-
-public class ConnectorConfiguration<S> {
+public class ConnectorConfiguration<S, D> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConnectorConfiguration.class);
 
-    private final static String PROPERTY_DATA_SHAPE = "data_shape";
-    private final static String PROPERTY_PROCESSORS = "processors";
-    private final static String PROPERTY_ERROR_HANDLER = "error_handler";
+    private static final String PROPERTY_DATA_SHAPE = "data_shape";
+    private static final String PROPERTY_PROCESSORS = "processors";
+    private static final String PROPERTY_ERROR_HANDLER = "error_handler";
     private static final Set<String> RESERVED_PROPERTIES = Set.of(PROPERTY_DATA_SHAPE, PROPERTY_PROCESSORS,
         PROPERTY_ERROR_HANDLER);
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
     private final S connectorSpec;
-    private final ObjectNode dataShapeSpec;
+    private final D dataShapeSpec;
     private final ObjectNode errorHandlerSpec;
     private final ArrayNode processorsSpec;
 
     @SuppressWarnings("unchecked")
-    public ConnectorConfiguration(ObjectNode connectorSpec, Class<S> type) {
+    public ConnectorConfiguration(ObjectNode connectorSpec, Class<S> connectorSpecType, Class<D> dataShapeType) {
         if (null == connectorSpec || connectorSpec.isEmpty()) {
             throw new RuntimeException("Connector spec can't be empty!");
         }
@@ -42,7 +38,11 @@ public class ConnectorConfiguration<S> {
             LOGGER.error("Missing `data_shape` in connector spec!");
             this.dataShapeSpec = null;
         } else {
-            this.dataShapeSpec = dataShape.deepCopy();
+            try {
+                this.dataShapeSpec = JSON_MAPPER.readValue(dataShape.toString(), dataShapeType);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
         }
 
         var errorHandler = connectorSpec.at("/" + PROPERTY_ERROR_HANDLER);
@@ -64,18 +64,14 @@ public class ConnectorConfiguration<S> {
 
         connectorSpec.remove(RESERVED_PROPERTIES);
 
-        if (type.isAssignableFrom(String.class)) {
+        if (connectorSpecType.isAssignableFrom(String.class)) {
             this.connectorSpec = (S) connectorSpec.toString();
-        } else if (type.isAssignableFrom(Properties.class)) {
-            Properties result = new Properties();
+        } else {
             try {
-                result.load(new StringReader(connectorSpec.toString()));
-            } catch (IOException e) {
+                this.connectorSpec = JSON_MAPPER.readValue(connectorSpec.toString(), connectorSpecType);
+            } catch (JsonProcessingException e) {
                 throw new RuntimeException(e);
             }
-            this.connectorSpec = (S) result;
-        } else {
-            this.connectorSpec = Serialization.unmarshal(connectorSpec.toString(), type);
         }
     }
 
@@ -83,7 +79,7 @@ public class ConnectorConfiguration<S> {
         return this.connectorSpec;
     }
 
-    public ObjectNode getDataShapeSpec() {
+    public D getDataShapeSpec() {
         return this.dataShapeSpec;
     }
 


### PR DESCRIPTION
* add optional types mapping for "data_shape"
* remove "Properties.class" type handling as it won't occur for connectorSpec
* fix OpenAPI example for `schema_registry.url` (will update OpenAPI spec in upstream fleetmanager repo later)

**open: add integration tests**

https://issues.redhat.com/browse/MGDCTRS-475