### PR TITLE
feat(MGDCTRS-614): prevent connector from being ready before klb deploy

### DIFF
--- a/cos-fleetshard-operator-camel-it/src/test/resources/CamelConnectorEvents.feature
+++ b/cos-fleetshard-operator-camel-it/src/test/resources/CamelConnectorEvents.feature
@@ -24,6 +24,6 @@ Feature: Camel Connector Status
 
     When the klb phase is "Ready" with conditions:
       | message   | reason   | status     | type     | lastTransitionTime        |
-      | a message | a reason | the status | the type | 2021-06-12T12:35:09+02:00 |
+      | a message | a reason | True       | Ready    | 2021-06-12T12:35:09+02:00 |
     Then the connector is in phase "Monitor"
     Then the deployment is in phase "ready"

--- a/cos-fleetshard-operator-camel-it/src/test/resources/CamelConnectorReSync.feature
+++ b/cos-fleetshard-operator-camel-it/src/test/resources/CamelConnectorReSync.feature
@@ -24,7 +24,7 @@ Feature: Camel Connector ReSync
 
     When the klb phase is "Ready" with conditions:
       | message   | reason   | status     | type     | lastTransitionTime        |
-      | a message | a reason | the status | the type | 2021-06-12T12:35:09+02:00 |
+      | a message | a reason | True       | Ready    | 2021-06-12T12:35:09+02:00 |
     Then the connector is in phase "Monitor"
      And the deployment is in phase "ready"
 

--- a/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandSupport.java
+++ b/cos-fleetshard-operator-camel/src/main/java/org/bf2/cos/fleetshard/operator/camel/CamelOperandSupport.java
@@ -379,7 +379,15 @@ public final class CamelOperandSupport {
         if (kameletBindingStatus.phase != null) {
             switch (kameletBindingStatus.phase.toLowerCase(Locale.US)) {
                 case KameletBindingStatus.PHASE_READY:
-                    statusSpec.setPhase(ManagedConnector.STATE_READY);
+                    statusSpec.setPhase(ManagedConnector.STATE_PROVISIONING);
+                    if (kameletBindingStatus.conditions != null) {
+                        boolean readyCondition = kameletBindingStatus.conditions.stream()
+                            .anyMatch(cond -> "Ready".equals(cond.getType())
+                                && "True".equals(cond.getStatus()));
+                        if (readyCondition) {
+                            statusSpec.setPhase(ManagedConnector.STATE_READY);
+                        }
+                    }
                     break;
                 case KameletBindingStatus.PHASE_ERROR:
                     statusSpec.setPhase(ManagedConnector.STATE_FAILED);


### PR DESCRIPTION
Waits for the Ready condition on the KameletBinding to be True before reporting the connector as Ready. 
Previously only the KameletBinding phased was being considered.