### PR TITLE
chore: add namespace tenant id and kind to metadata.lables

### DIFF
--- a/cos-fleetshard-support/src/main/java/org/bf2/cos/fleetshard/support/resources/Resources.java
+++ b/cos-fleetshard-support/src/main/java/org/bf2/cos/fleetshard/support/resources/Resources.java
@@ -36,10 +36,11 @@ public final class Resources {
     public static final String ANNOTATION_UPDATED_TIMESTAMP = "cos.bf2.org/update.timestamp";
     public static final String ANNOTATION_NAMESPACE_NAME = "cos.bf2.org/namespace.name";
     public static final String ANNOTATION_NAMESPACE_EXPIRATION = "cos.bf2.org/namespace.expiration";
-    public static final String ANNOTATION_NAMESPACE_STATE = "cos.bf2.org/namespace.state";
-    public static final String ANNOTATION_NAMESPACE_TENAT_KIND = "cos.bf2.org/namespace.tenant.kind";
-    public static final String ANNOTATION_NAMESPACE_TENAT_ID = "cos.bf2.org/namespace.tenant.id";
     public static final String ANNOTATION_NAMESPACE_RESOURCE_VERSION = "cos.bf2.org/namespace.resource.version";
+    public static final String ANNOTATION_NAMESPACE_STATE = "cos.bf2.org/namespace.state";
+
+    public static final String LABEL_NAMESPACE_TENANT_KIND = "cos.bf2.org/namespace.tenant.kind";
+    public static final String LABEL_NAMESPACE_TENANT_ID = "cos.bf2.org/namespace.tenant.id";
 
     public static final String CONNECTOR_PREFIX = "mctr-";
     public static final String CONNECTOR_SECRET_SUFFIX = "-config";

--- a/cos-fleetshard-sync-it/src/test/java/org/bf2/cos/fleetshard/sync/it/NamespaceProvisionerTest.java
+++ b/cos-fleetshard-sync-it/src/test/java/org/bf2/cos/fleetshard/sync/it/NamespaceProvisionerTest.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import javax.inject.Inject;
 import javax.ws.rs.core.MediaType;
 
+import org.bf2.cos.fleet.manager.model.ConnectorNamespaceTenantKind;
 import org.bf2.cos.fleetshard.support.resources.Namespaces;
 import org.bf2.cos.fleetshard.support.resources.Resources;
 import org.bf2.cos.fleetshard.sync.FleetShardSyncConfig;
@@ -59,7 +60,9 @@ public class NamespaceProvisionerTest extends NamespaceProvisionerTestBase {
                 .containsEntry(Resources.LABEL_KUBERNETES_CREATED_BY, fleetShardClient.getClusterId())
                 .containsEntry(Resources.LABEL_KUBERNETES_PART_OF, fleetShardClient.getClusterId())
                 .containsEntry(Resources.LABEL_KUBERNETES_COMPONENT, Resources.COMPONENT_NAMESPACE)
-                .containsEntry(Resources.LABEL_KUBERNETES_INSTANCE, deployment1);
+                .containsEntry(Resources.LABEL_KUBERNETES_INSTANCE, deployment1)
+                .containsEntry(Resources.LABEL_NAMESPACE_TENANT_KIND, ConnectorNamespaceTenantKind.ORGANISATION.getValue())
+                .containsKey(Resources.LABEL_NAMESPACE_TENANT_ID);
         });
 
         checkAddonPullSecretCopiedSuccessfullyToNamespace(ns1);
@@ -79,7 +82,9 @@ public class NamespaceProvisionerTest extends NamespaceProvisionerTestBase {
                 .containsEntry(Resources.LABEL_KUBERNETES_CREATED_BY, fleetShardClient.getClusterId())
                 .containsEntry(Resources.LABEL_KUBERNETES_PART_OF, fleetShardClient.getClusterId())
                 .containsEntry(Resources.LABEL_KUBERNETES_COMPONENT, Resources.COMPONENT_NAMESPACE)
-                .containsEntry(Resources.LABEL_KUBERNETES_INSTANCE, deployment2);
+                .containsEntry(Resources.LABEL_KUBERNETES_INSTANCE, deployment2)
+                .containsEntry(Resources.LABEL_NAMESPACE_TENANT_KIND, ConnectorNamespaceTenantKind.ORGANISATION.getValue())
+                .containsKey(Resources.LABEL_NAMESPACE_TENANT_ID);
         });
 
         checkAddonPullSecretCopiedSuccessfullyToNamespace(ns2);

--- a/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/resources/ConnectorNamespaceProvisioner.java
+++ b/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/resources/ConnectorNamespaceProvisioner.java
@@ -94,14 +94,14 @@ public class ConnectorNamespaceProvisioner {
             Resources.LABEL_KUBERNETES_PART_OF, fleetShard.getClusterId(),
             Resources.LABEL_KUBERNETES_COMPONENT, Resources.COMPONENT_NAMESPACE,
             Resources.LABEL_KUBERNETES_INSTANCE, namespace.getId(),
-            Resources.LABEL_KUBERNETES_VERSION, "" + namespace.getResourceVersion());
+            Resources.LABEL_KUBERNETES_VERSION, "" + namespace.getResourceVersion(),
+            Resources.LABEL_NAMESPACE_TENANT_KIND, namespace.getTenant().getKind().getValue(),
+            Resources.LABEL_NAMESPACE_TENANT_ID, namespace.getTenant().getId());
 
         Resources.setAnnotations(
             ns,
             Resources.ANNOTATION_NAMESPACE_STATE, namespace.getStatus().getState().getValue(),
-            Resources.ANNOTATION_NAMESPACE_EXPIRATION, namespace.getExpiration(),
-            Resources.ANNOTATION_NAMESPACE_TENAT_KIND, namespace.getTenant().getKind().toString(),
-            Resources.ANNOTATION_NAMESPACE_TENAT_ID, namespace.getTenant().getId());
+            Resources.ANNOTATION_NAMESPACE_EXPIRATION, namespace.getExpiration());
 
         fleetShard.getKubernetesClient().namespaces().createOrReplace(ns);
 


### PR DESCRIPTION
So we can search for user/org namespaces using label selection:

    kubectl get ns -l "cos.bf2.org/namespace.tenant.kind=user"   