### PR TITLE
MGDCTRS-811 Debezium Postgres Connector should use `pgoutput` plugin instead of `decoderbufs` as default

### DIFF
--- a/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorReifyAvro.feature
+++ b/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorReifyAvro.feature
@@ -80,7 +80,5 @@ Feature: Debezium Connector Reify
      And the kctr has an entry at path "$.spec.tasksMax" with value 1
      And the kctr has an entry at path "$.spec.class" with value "io.debezium.connector.postgresql.PostgresConnector"
      And the kctr has config containing:
-       | database.password                 | ${file:/opt/kafka/external-configuration/connector-configuration/debezium-connector.properties:database.password} |
-
-
-
+       | database.password           | ${file:/opt/kafka/external-configuration/connector-configuration/debezium-connector.properties:database.password} |
+       | plugin.name                 | pgoutput                                                                                                          |

--- a/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorReifyJsonWithSchema.feature
+++ b/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorReifyJsonWithSchema.feature
@@ -79,7 +79,5 @@ Feature: Debezium Connector Reify
      And the kctr has an entry at path "$.spec.tasksMax" with value 1
      And the kctr has an entry at path "$.spec.class" with value "io.debezium.connector.postgresql.PostgresConnector"
      And the kctr has config containing:
-       | database.password                 | ${file:/opt/kafka/external-configuration/connector-configuration/debezium-connector.properties:database.password} |
-
-
-
+       | database.password           | ${file:/opt/kafka/external-configuration/connector-configuration/debezium-connector.properties:database.password} |
+       | plugin.name                 | pgoutput                                                                                                          |

--- a/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorReifySchemalessJson.feature
+++ b/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorReifySchemalessJson.feature
@@ -78,7 +78,5 @@ Feature: Debezium Connector Reify
      And the kctr has an entry at path "$.spec.tasksMax" with value 1
      And the kctr has an entry at path "$.spec.class" with value "io.debezium.connector.postgresql.PostgresConnector"
      And the kctr has config containing:
-       | database.password                 | ${file:/opt/kafka/external-configuration/connector-configuration/debezium-connector.properties:database.password} |
-
-
-
+       | database.password           | ${file:/opt/kafka/external-configuration/connector-configuration/debezium-connector.properties:database.password} |
+       | plugin.name                 | pgoutput                                                                                                          |

--- a/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorReifyWithExternalConfig.feature
+++ b/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorReifyWithExternalConfig.feature
@@ -61,7 +61,5 @@ Feature: Debezium Connector Reify
     And the kctr has an entry at path "$.spec.tasksMax" with value 1
     And the kctr has an entry at path "$.spec.class" with value "io.debezium.connector.postgresql.PostgresConnector"
     And the kctr has config containing:
-      | database.password                 | ${file:/opt/kafka/external-configuration/connector-configuration/debezium-connector.properties:database.password} |
-
-
-
+      | database.password           | ${file:/opt/kafka/external-configuration/connector-configuration/debezium-connector.properties:database.password} |
+      | plugin.name                 | pgoutput                                                                                                          |

--- a/cos-fleetshard-operator-debezium/src/test/java/org/bf2/cos/fleetshard/operator/debezium/DebeziumOperandControllerTest.java
+++ b/cos-fleetshard-operator-debezium/src/test/java/org/bf2/cos/fleetshard/operator/debezium/DebeziumOperandControllerTest.java
@@ -240,14 +240,18 @@ public class DebeziumOperandControllerTest {
             .filteredOn(DebeziumOperandSupport::isKafkaConnector)
             .hasSize(1)
             .first()
-            .isInstanceOfSatisfying(KafkaConnector.class, kc -> assertThat(
-                kc.getSpec().getConfig()).containsEntry(
-                    "database.password",
-                    "${file:/opt/kafka/external-configuration/"
-                        + DebeziumConstants.EXTERNAL_CONFIG_DIRECTORY
-                        + "/"
-                        + EXTERNAL_CONFIG_FILE
-                        + ":database.password}"));
+            .isInstanceOfSatisfying(KafkaConnector.class, kctr -> {
+                assertThat(
+                    kctr.getSpec().getConfig()).containsEntry(
+                        "database.password",
+                        "${file:/opt/kafka/external-configuration/"
+                            + DebeziumConstants.EXTERNAL_CONFIG_DIRECTORY
+                            + "/"
+                            + EXTERNAL_CONFIG_FILE
+                            + ":database.password}");
+                assertThat(kctr.getSpec().getConfig().get(DebeziumOperandController.CONFIG_OPTION_POSTGRES_PLUGIN_NAME))
+                    .isEqualTo(DebeziumOperandController.PLUGIN_NAME_PGOUTPUT);
+            });
 
         assertThat(resources)
             .filteredOn(DebeziumOperandSupport::isKafkaConnect)


### PR DESCRIPTION
closes https://issues.redhat.com/browse/MGDCTRS-811