### PR TITLE
Set limit ranges assigned to a kubernetes namwspace

### DIFF
--- a/cos-fleetshard-sync-it/src/test/java/org/bf2/cos/fleetshard/sync/it/NamespaceProvisionerWithNoQuotaTestBase.java
+++ b/cos-fleetshard-sync-it/src/test/java/org/bf2/cos/fleetshard/sync/it/NamespaceProvisionerWithNoQuotaTestBase.java
@@ -13,6 +13,7 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Test;
 
+import io.fabric8.kubernetes.api.model.LimitRange;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.ResourceQuota;
 import io.restassured.RestAssured;
@@ -70,6 +71,17 @@ public abstract class NamespaceProvisionerWithNoQuotaTestBase extends SyncTestSu
                     .resourceQuotas()
                     .inNamespace(ns.getMetadata().getName())
                     .withName(ns.getMetadata().getName() + "-quota")
+                    .get();
+
+                assertThat(answer).isNull();
+            });
+
+        untilAsserted(
+            () -> {
+                LimitRange answer = fleetShardClient.getKubernetesClient()
+                    .limitRanges()
+                    .inNamespace(ns.getMetadata().getName())
+                    .withName(ns.getMetadata().getName() + "-limits")
                     .get();
 
                 assertThat(answer).isNull();

--- a/cos-fleetshard-sync-it/src/test/java/org/bf2/cos/fleetshard/sync/it/support/SyncTestSupport.java
+++ b/cos-fleetshard-sync-it/src/test/java/org/bf2/cos/fleetshard/sync/it/support/SyncTestSupport.java
@@ -10,6 +10,7 @@ import java.util.function.Predicate;
 
 import javax.inject.Inject;
 
+import org.assertj.core.api.ThrowingConsumer;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionFactory;
 import org.awaitility.core.ThrowingRunnable;
@@ -35,6 +36,7 @@ import io.fabric8.kubernetes.client.utils.Serialization;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.bf2.cos.fleetshard.support.resources.Resources.uid;
 
 public class SyncTestSupport {
@@ -142,6 +144,15 @@ public class SyncTestSupport {
             .pollDelay(100, TimeUnit.MILLISECONDS)
             .pollInterval(500, TimeUnit.MILLISECONDS)
             .untilAsserted(runnable);
+    }
+
+    public static <T> void untilAsserted(Callable<Optional<T>> supplier, ThrowingConsumer<T> consumer) {
+        getConditionFactory().untilAsserted(() -> {
+            assertThat(supplier.call())
+                .isPresent()
+                .get()
+                .satisfies(consumer);
+        });
     }
 
     public static StringValuePattern jp(String expression, String expected) {

--- a/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/FleetShardSyncConfig.java
+++ b/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/FleetShardSyncConfig.java
@@ -3,12 +3,14 @@ package org.bf2.cos.fleetshard.sync;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 
 import org.bf2.cos.fleetshard.api.ManagedConnector;
 import org.bf2.cos.fleetshard.api.ManagedConnectorCluster;
 import org.bf2.cos.fleetshard.support.DurationConverter;
 import org.bf2.cos.fleetshard.sync.resources.ConnectorNamespaceProvisioner;
 
+import io.fabric8.kubernetes.api.model.Quantity;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithConverter;
 import io.smallrye.config.WithDefault;
@@ -96,6 +98,24 @@ public interface FleetShardSyncConfig {
     interface Quota {
         @WithDefault("true")
         boolean enabled();
+
+        DefaultLimits defaultLimits();
+
+        DefaultRequest defaultRequest();
+    }
+
+    interface DefaultLimits {
+        Optional<Quantity> cpu();
+
+        Optional<Quantity> memory();
+    }
+
+    interface DefaultRequest {
+        @WithDefault("200m")
+        Quantity cpu();
+
+        @WithDefault("128m")
+        Quantity memory();
     }
 
     interface Resources {

--- a/cos-fleetshard-sync/src/main/kubernetes/kubernetes.yml
+++ b/cos-fleetshard-sync/src/main/kubernetes/kubernetes.yml
@@ -59,6 +59,23 @@ rules:
     - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cos-fleetshard-sync-limits
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - limitranges
+    verbs:
+      - create
+      - patch
+      - get
+      - list
+      - watch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cos-fleetshard-sync-connectors
@@ -79,6 +96,19 @@ roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
   name: cos-fleetshard-sync-quota
+subjects:
+  - kind: ServiceAccount
+    name: cos-fleetshard-sync
+    namespace: placeholder
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cos-fleetshard-sync-limits
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: cos-fleetshard-sync-limits
 subjects:
   - kind: ServiceAccount
     name: cos-fleetshard-sync

--- a/cos-fleetshard-sync/src/main/kubernetes/kubernetes.yml
+++ b/cos-fleetshard-sync/src/main/kubernetes/kubernetes.yml
@@ -51,9 +51,12 @@ rules:
   resources:
     - resourcequotas
   verbs:
-    - delete
+    - create
+    - patch
     - get
     - list
+    - watch
+    - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cos-fleetshard-sync/src/test/java/org/bf2/cos/fleetshard/sync/connector/ConnectorTestSupport.java
+++ b/cos-fleetshard-sync/src/test/java/org/bf2/cos/fleetshard/sync/connector/ConnectorTestSupport.java
@@ -228,6 +228,12 @@ public final class ConnectorTestSupport {
         when(answer.quota()).thenAnswer(invocation -> {
             return Mockito.mock(FleetShardSyncConfig.Quota.class);
         });
+        when(answer.quota().defaultLimits()).thenAnswer(invocation -> {
+            return Mockito.mock(FleetShardSyncConfig.DefaultLimits.class);
+        });
+        when(answer.quota().defaultRequest()).thenAnswer(invocation -> {
+            return Mockito.mock(FleetShardSyncConfig.DefaultRequest.class);
+        });
 
         return answer;
     }

--- a/etc/kubernetes/manifests/base/apps/cos-fleetshard-sync/kubernetes.yml
+++ b/etc/kubernetes/manifests/base/apps/cos-fleetshard-sync/kubernetes.yml
@@ -168,6 +168,23 @@ rules:
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: "ClusterRole"
 metadata:
+  name: "cos-fleetshard-sync-limits"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "limitranges"
+  verbs:
+  - "create"
+  - "patch"
+  - "get"
+  - "list"
+  - "watch"
+  - "update"
+---
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: "ClusterRole"
+metadata:
   name: "cos-fleetshard-sync-quota"
 rules:
 - apiGroups:
@@ -175,9 +192,12 @@ rules:
   resources:
   - "resourcequotas"
   verbs:
-  - "delete"
+  - "create"
+  - "patch"
   - "get"
   - "list"
+  - "watch"
+  - "update"
 ---
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: "ClusterRoleBinding"
@@ -200,6 +220,19 @@ roleRef:
   apiGroup: "rbac.authorization.k8s.io"
   kind: "ClusterRole"
   name: "cos-fleetshard-sync-events"
+subjects:
+- kind: "ServiceAccount"
+  name: "cos-fleetshard-sync"
+  namespace: "placeholder"
+---
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: "ClusterRoleBinding"
+metadata:
+  name: "cos-fleetshard-sync-limits"
+roleRef:
+  apiGroup: "rbac.authorization.k8s.io"
+  kind: "ClusterRole"
+  name: "cos-fleetshard-sync-limits"
 subjects:
 - kind: "ServiceAccount"
   name: "cos-fleetshard-sync"
@@ -256,10 +289,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: "metadata.namespace"
-        - name: "SMALLRYE_CONFIG_SOURCE_FILE_LOCATIONS"
-          value: "/mnt/app-secret"
         - name: "SMALLRYE_CONFIG_LOCATIONS"
           value: "/mnt/app-config"
+        - name: "SMALLRYE_CONFIG_SOURCE_FILE_LOCATIONS"
+          value: "/mnt/app-secret"
         image: "quay.io/rhoas/cos-fleetshard-sync:latest"
         imagePullPolicy: "Always"
         livenessProbe:


### PR DESCRIPTION
With this PR a new `LimitRange` resource is created in any namespace where resource quota are configured assuming that at this stage, only eval namespace have such quota set.
 
The reason of such resource to be created is that,  when allocating compute resources, each container may specify a request and a limit value for either CPU or memory and the quota can be configured to quota either value per namespace but if the quota has a value specified for requests.cpu or requests.memory, then it requires that every container makes an explicit request for those resources. If the quota has a value specified for limits.cpu or limits.memory, then it requires that every incoming container specifies an explicit limit for those resources.

Since not our connector do explicit specify limits, a `LimitRange` can be used to automatically set them:

```yaml
apiVersion: v1
kind: LimitRange
metadata:
  name: redhat-openshift-connectors-ca5j6vufrusf747mmmmg-ranges
spec:
  limits:
  - default:
      cpu: 500m
      memory: 500m
    defaultRequest:
      cpu: 200m
      memory: 128m
    type: Container
```

With this set-up each new container that is created on the eval namespace, will receive a default limit computed taking into account the limits sets on the namespace and the number of connectors that are allowed to be created to the namespace.

