### PR TITLE
feat: replace programmatic creation of meters with injection

### DIFF
--- a/cos-fleetshard-support/src/main/java/org/bf2/cos/fleetshard/support/metrics/StaticMetricsRecorder.java
+++ b/cos-fleetshard-support/src/main/java/org/bf2/cos/fleetshard/support/metrics/StaticMetricsRecorder.java
@@ -1,0 +1,97 @@
+package org.bf2.cos.fleetshard.support.metrics;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+
+import org.bf2.cos.fleetshard.support.exceptions.WrappedRuntimeException;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+
+public class StaticMetricsRecorder {
+    private final MeterRegistry registry;
+    private final String id;
+    private final List<Tag> tags;
+
+    private final Timer timer;
+    private final Counter counter;
+
+    private StaticMetricsRecorder(MeterRegistry registry, String id, List<Tag> tags) {
+        this.registry = registry;
+        this.id = id;
+        this.tags = tags;
+
+        this.timer = Timer.builder(id + ".time")
+            .tags(tags)
+            .register(registry);
+        this.counter = Counter.builder(id + ".count")
+            .tags(tags)
+            .register(registry);
+    }
+
+    public void record(Runnable action) {
+        record(
+            action,
+            e -> {
+                throw new WrappedRuntimeException(
+                    "Failure recording method execution (id: " + id + ")",
+                    e);
+            });
+    }
+
+    public void record(Runnable action, Consumer<Exception> exceptionHandler) {
+        try {
+            timer.record(action);
+            counter.increment();
+        } catch (Exception e) {
+            Counter.builder(id + ".count.failure")
+                .tags(tags)
+                .tag("exception", e.getClass().getName())
+                .register(registry)
+                .increment();
+
+            exceptionHandler.accept(e);
+        }
+    }
+
+    public <T> T recordCallable(Callable<T> action) {
+        return recordCallable(
+            action,
+            e -> {
+                throw new WrappedRuntimeException(
+                    "Failure recording method execution (id: " + id + ")",
+                    e);
+            });
+    }
+
+    public <T> T recordCallable(Callable<T> action, Consumer<Exception> exceptionHandler) {
+        try {
+            var answer = timer.recordCallable(action);
+            counter.increment();
+
+            return answer;
+        } catch (Exception e) {
+            Counter.builder(id + ".count.failure")
+                .tags(tags)
+                .tag("exception", e.getClass().getName())
+                .register(registry)
+                .increment();
+
+            exceptionHandler.accept(e);
+        }
+
+        return null;
+    }
+
+    public static StaticMetricsRecorder of(MeterRegistry registry, String id) {
+        return new StaticMetricsRecorder(registry, id, Collections.emptyList());
+    }
+
+    public static StaticMetricsRecorder of(MeterRegistry registry, String id, List<Tag> tags) {
+        return new StaticMetricsRecorder(registry, id, tags);
+    }
+}

--- a/cos-fleetshard-sync-it/src/test/java/org/bf2/cos/fleetshard/sync/it/NamespaceReaperDelReprovisionTestBase.java
+++ b/cos-fleetshard-sync-it/src/test/java/org/bf2/cos/fleetshard/sync/it/NamespaceReaperDelReprovisionTestBase.java
@@ -8,6 +8,7 @@ import javax.ws.rs.core.MediaType;
 import org.bf2.cos.fleetshard.support.resources.Resources;
 import org.bf2.cos.fleetshard.sync.it.support.FleetManagerMockServer;
 import org.bf2.cos.fleetshard.sync.it.support.FleetManagerTestInstance;
+import org.bf2.cos.fleetshard.sync.it.support.MetricsSupport;
 import org.bf2.cos.fleetshard.sync.resources.ConnectorNamespaceProvisioner;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.Test;
@@ -34,8 +35,7 @@ public class NamespaceReaperDelReprovisionTestBase extends NamespaceReaperTestSu
             .post("/test/provisioner/namespaces");
 
         untilAsserted(() -> {
-            assertThat(
-                registry.find(config.metrics().baseName() + ConnectorNamespaceProvisioner.METRICS_SUFFIX + ".count").counter())
+            assertThat(MetricsSupport.counter(registry, config, ConnectorNamespaceProvisioner.METRICS_SUFFIX, ".count"))
                 .isNotNull()
                 .satisfies(counter -> assertThat(counter.count()).isEqualTo(1));
         });
@@ -50,8 +50,7 @@ public class NamespaceReaperDelReprovisionTestBase extends NamespaceReaperTestSu
             .post("/test/provisioner/namespaces");
 
         untilAsserted(() -> {
-            assertThat(
-                registry.find(config.metrics().baseName() + ConnectorNamespaceProvisioner.METRICS_SUFFIX + ".count").counter())
+            assertThat(MetricsSupport.counter(registry, config, ConnectorNamespaceProvisioner.METRICS_SUFFIX, ".count"))
                 .isNotNull()
                 .satisfies(counter -> assertThat(counter.count()).isEqualTo(2));
         });
@@ -66,8 +65,7 @@ public class NamespaceReaperDelReprovisionTestBase extends NamespaceReaperTestSu
             .post("/test/provisioner/namespaces");
 
         untilAsserted(() -> {
-            assertThat(
-                registry.find(config.metrics().baseName() + ConnectorNamespaceProvisioner.METRICS_SUFFIX + ".count").counter())
+            assertThat(MetricsSupport.counter(registry, config, ConnectorNamespaceProvisioner.METRICS_SUFFIX, ".count"))
                 .isNotNull()
                 .satisfies(counter -> assertThat(counter.count()).isEqualTo(3));
         });

--- a/cos-fleetshard-sync-it/src/test/java/org/bf2/cos/fleetshard/sync/it/support/MetricsSupport.java
+++ b/cos-fleetshard-sync-it/src/test/java/org/bf2/cos/fleetshard/sync/it/support/MetricsSupport.java
@@ -1,0 +1,35 @@
+package org.bf2.cos.fleetshard.sync.it.support;
+
+import org.bf2.cos.fleetshard.sync.FleetShardSyncConfig;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.Search;
+
+public final class MetricsSupport {
+    private MetricsSupport() {
+    }
+
+    public static Search find(MeterRegistry registry, FleetShardSyncConfig config, String... subs) {
+        return find(registry, config.metrics().baseName(), subs);
+    }
+
+    public static Search find(MeterRegistry registry, String base, String... subs) {
+        String id = base;
+
+        if (subs.length > 0) {
+            id += "." + String.join(".", subs);
+            id = id.replace("..", ".");
+        }
+
+        return registry.find(id);
+    }
+
+    public static Counter counter(MeterRegistry registry, FleetShardSyncConfig config, String... subs) {
+        return find(registry, config, subs).counter();
+    }
+
+    public static Counter counter(MeterRegistry registry, String base, String... subs) {
+        return find(registry, base, subs).counter();
+    }
+}

--- a/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/housekeeping/Housekeeper.java
+++ b/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/housekeeping/Housekeeper.java
@@ -9,10 +9,10 @@ import org.bf2.cos.fleetshard.support.Service;
 import org.bf2.cos.fleetshard.support.metrics.MetricsRecorder;
 import org.bf2.cos.fleetshard.sync.FleetShardSyncConfig;
 import org.bf2.cos.fleetshard.sync.FleetShardSyncScheduler;
+import org.bf2.cos.fleetshard.sync.metrics.MetricsID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.arc.All;
 
 @ApplicationScoped
@@ -26,13 +26,14 @@ public class Housekeeper implements Service {
     FleetShardSyncConfig config;
     @Inject
     FleetShardSyncScheduler scheduler;
-    @Inject
-    MeterRegistry registry;
+
     @Inject
     @All
     List<Task> tasks;
 
-    private volatile MetricsRecorder recorder;
+    @Inject
+    @MetricsID(METRICS_ID)
+    MetricsRecorder recorder;
 
     @Override
     public void start() throws Exception {
@@ -46,8 +47,6 @@ public class Housekeeper implements Service {
                 ((Service) task).start();
             }
         }
-
-        recorder = MetricsRecorder.of(registry, config.metrics().baseName() + "." + METRICS_ID);
 
         scheduler.schedule(
             JOB_ID,

--- a/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/metrics/MetricsProducers.java
+++ b/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/metrics/MetricsProducers.java
@@ -10,8 +10,10 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.bf2.cos.fleetshard.support.metrics.MetricsRecorder;
+import org.bf2.cos.fleetshard.support.metrics.StaticMetricsRecorder;
 import org.bf2.cos.fleetshard.sync.FleetShardSyncConfig;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 
@@ -48,5 +50,62 @@ public class MetricsProducers {
             tags == null
                 ? Collections.emptyList()
                 : Stream.of(tags.value()).map(t -> Tag.of(t.key(), t.value())).collect(Collectors.toList()));
+    }
+
+    @Produces
+    public StaticMetricsRecorder staticRecorder(InjectionPoint ip) {
+        MetricsID named = ip.getAnnotated().getAnnotation(MetricsID.class);
+        if (named == null) {
+            throw new IllegalArgumentException("Missing MetricsID annotation");
+        }
+        if (named.value() == null || named.value().trim().isEmpty()) {
+            throw new IllegalArgumentException("Missing metrics id");
+        }
+
+        MetricsTags tags = ip.getAnnotated().getAnnotation(MetricsTags.class);
+        if (tags != null && tags.value() == null) {
+            throw new IllegalArgumentException("Missing metrics tags");
+        }
+
+        String id = named.value();
+        if (!id.startsWith(config.metrics().baseName() + ".")) {
+            id = config.metrics().baseName() + "." + id;
+        }
+
+        return StaticMetricsRecorder.of(
+            registry,
+            id,
+            tags == null
+                ? Collections.emptyList()
+                : Stream.of(tags.value()).map(t -> Tag.of(t.key(), t.value())).collect(Collectors.toList()));
+    }
+
+    @Produces
+    public Counter counter(InjectionPoint ip) {
+        MetricsID named = ip.getAnnotated().getAnnotation(MetricsID.class);
+        if (named == null) {
+            throw new IllegalArgumentException("Missing MetricsID annotation");
+        }
+        if (named.value() == null || named.value().trim().isEmpty()) {
+            throw new IllegalArgumentException("Missing metrics id");
+        }
+
+        MetricsTags tags = ip.getAnnotated().getAnnotation(MetricsTags.class);
+        if (tags != null && tags.value() == null) {
+            throw new IllegalArgumentException("Missing metrics tags");
+        }
+
+        String id = named.value();
+        if (!id.startsWith(config.metrics().baseName() + ".")) {
+            id = config.metrics().baseName() + "." + id;
+        }
+
+        Counter.Builder builder = Counter.builder(id);
+        if (tags != null) {
+            builder = builder.tags(
+                Stream.of(tags.value()).map(t -> Tag.of(t.key(), t.value())).collect(Collectors.toList()));
+        }
+
+        return builder.register(registry);
     }
 }

--- a/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/resources/ConnectorClusterStatusSync.java
+++ b/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/resources/ConnectorClusterStatusSync.java
@@ -13,7 +13,7 @@ import org.bf2.cos.fleet.manager.model.ConnectorNamespaceDeploymentStatus;
 import org.bf2.cos.fleet.manager.model.ConnectorNamespaceState;
 import org.bf2.cos.fleet.manager.model.ConnectorOperator;
 import org.bf2.cos.fleetshard.support.Service;
-import org.bf2.cos.fleetshard.support.metrics.MetricsRecorder;
+import org.bf2.cos.fleetshard.support.metrics.StaticMetricsRecorder;
 import org.bf2.cos.fleetshard.support.resources.Namespaces;
 import org.bf2.cos.fleetshard.support.resources.Operators;
 import org.bf2.cos.fleetshard.support.resources.Resources;
@@ -21,10 +21,9 @@ import org.bf2.cos.fleetshard.sync.FleetShardSyncConfig;
 import org.bf2.cos.fleetshard.sync.FleetShardSyncScheduler;
 import org.bf2.cos.fleetshard.sync.client.FleetManagerClient;
 import org.bf2.cos.fleetshard.sync.client.FleetShardClient;
+import org.bf2.cos.fleetshard.sync.metrics.MetricsID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.micrometer.core.instrument.MeterRegistry;
 
 @ApplicationScoped
 public class ConnectorClusterStatusSync implements Service {
@@ -40,17 +39,15 @@ public class ConnectorClusterStatusSync implements Service {
     @Inject
     FleetShardSyncConfig config;
     @Inject
-    MeterRegistry registry;
-    @Inject
     ConnectorClusterPlatform platform;
 
-    private volatile MetricsRecorder recorder;
+    @Inject
+    @MetricsID(JOB_ID)
+    StaticMetricsRecorder recorder;
 
     @Override
     public void start() throws Exception {
         LOGGER.info("Starting connector status sync");
-
-        recorder = MetricsRecorder.of(registry, config.metrics().baseName() + "." + JOB_ID);
 
         scheduler.schedule(
             JOB_ID,

--- a/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/resources/ResourcePoll.java
+++ b/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/resources/ResourcePoll.java
@@ -8,13 +8,12 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.bf2.cos.fleetshard.support.Service;
-import org.bf2.cos.fleetshard.support.metrics.MetricsRecorder;
+import org.bf2.cos.fleetshard.support.metrics.StaticMetricsRecorder;
 import org.bf2.cos.fleetshard.sync.FleetShardSyncConfig;
 import org.bf2.cos.fleetshard.sync.FleetShardSyncScheduler;
 import org.bf2.cos.fleetshard.sync.client.FleetShardClient;
+import org.bf2.cos.fleetshard.sync.metrics.MetricsID;
 import org.eclipse.microprofile.faulttolerance.Retry;
-
-import io.micrometer.core.instrument.MeterRegistry;
 
 @ApplicationScoped
 public class ResourcePoll implements Service {
@@ -33,17 +32,18 @@ public class ResourcePoll implements Service {
     ConnectorDeploymentProvisioner connectorsProvisioner;
     @Inject
     ConnectorNamespaceProvisioner namespaceProvisioner;
-    @Inject
-    MeterRegistry registry;
 
-    private volatile MetricsRecorder syncRecorder;
-    private volatile MetricsRecorder pollRecorder;
+    @Inject
+    @MetricsID(METRICS_SYNC)
+    StaticMetricsRecorder syncRecorder;
+    @Inject
+    @MetricsID(METRICS_POLL)
+    StaticMetricsRecorder pollRecorder;
+
     private volatile Instant lastResync;
 
     @Override
     public void start() throws Exception {
-        syncRecorder = MetricsRecorder.of(registry, config.metrics().baseName() + "." + METRICS_SYNC);
-        pollRecorder = MetricsRecorder.of(registry, config.metrics().baseName() + "." + METRICS_POLL);
 
         scheduler.schedule(
             JOB_ID,

--- a/cos-fleetshard-sync/src/test/java/org/bf2/cos/fleetshard/sync/resources/ConnectorProvisionerTest.java
+++ b/cos-fleetshard-sync/src/test/java/org/bf2/cos/fleetshard/sync/resources/ConnectorProvisionerTest.java
@@ -1,4 +1,4 @@
-package org.bf2.cos.fleetshard.sync.connector;
+package org.bf2.cos.fleetshard.sync.resources;
 
 import java.util.List;
 import java.util.UUID;
@@ -8,12 +8,10 @@ import org.bf2.cos.fleet.manager.model.ServiceAccount;
 import org.bf2.cos.fleetshard.api.ManagedConnector;
 import org.bf2.cos.fleetshard.api.ManagedConnectorBuilder;
 import org.bf2.cos.fleetshard.support.client.EventClient;
+import org.bf2.cos.fleetshard.support.metrics.MetricsRecorder;
 import org.bf2.cos.fleetshard.support.resources.Connectors;
 import org.bf2.cos.fleetshard.support.resources.Secrets;
-import org.bf2.cos.fleetshard.sync.FleetShardSyncConfig;
-import org.bf2.cos.fleetshard.sync.client.FleetManagerClient;
-import org.bf2.cos.fleetshard.sync.client.FleetShardClient;
-import org.bf2.cos.fleetshard.sync.resources.ConnectorDeploymentProvisioner;
+import org.bf2.cos.fleetshard.sync.connector.ConnectorTestSupport;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -23,7 +21,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.micrometer.core.instrument.MeterRegistry;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,29 +45,24 @@ public class ConnectorProvisionerTest {
         final List<ManagedConnector> connectors = List.of();
         final List<Secret> secrets = List.of();
 
-        final FleetShardClient fleetShard = ConnectorTestSupport.fleetShard(CLUSTER_ID, connectors, secrets);
-        final FleetManagerClient fleetManager = ConnectorTestSupport.fleetManagerClient();
-        final FleetShardSyncConfig config = ConnectorTestSupport.config();
-        final MeterRegistry registry = Mockito.mock(MeterRegistry.class);
-        final EventClient eventClient = Mockito.mock(EventClient.class);
-
         final ArgumentCaptor<Secret> sc = ArgumentCaptor.forClass(Secret.class);
         final ArgumentCaptor<ManagedConnector> mcc = ArgumentCaptor.forClass(ManagedConnector.class);
 
-        final ConnectorDeploymentProvisioner provisioner = new ConnectorDeploymentProvisioner(
-            config,
-            fleetShard,
-            fleetManager,
-            registry,
-            eventClient);
+        final ConnectorDeploymentProvisioner provisioner = new ConnectorDeploymentProvisioner();
+        provisioner.config = ConnectorTestSupport.config();
+        ;
+        provisioner.fleetShard = ConnectorTestSupport.fleetShard(CLUSTER_ID, connectors, secrets);
+        provisioner.fleetManager = ConnectorTestSupport.fleetManagerClient();
+        provisioner.eventClient = Mockito.mock(EventClient.class);
+        provisioner.recorder = Mockito.mock(MetricsRecorder.class);
 
         //
         // When deployment is applied
         //
         provisioner.provision(deployment);
 
-        verify(fleetShard).createSecret(sc.capture());
-        verify(fleetShard).createConnector(mcc.capture());
+        verify(provisioner.fleetShard).createSecret(sc.capture());
+        verify(provisioner.fleetShard).createConnector(mcc.capture());
 
         //
         // Then resources must be created according to the deployment
@@ -161,13 +153,14 @@ public class ConnectorProvisionerTest {
                     .build())
                 .build());
 
-        final FleetShardClient fleetShard = ConnectorTestSupport.fleetShard(CLUSTER_ID, connectors, secrets);
-        final FleetManagerClient fleetManager = ConnectorTestSupport.fleetManagerClient();
-        final FleetShardSyncConfig config = ConnectorTestSupport.config();
-        final MeterRegistry registry = Mockito.mock(MeterRegistry.class);
-        final EventClient eventClient = Mockito.mock(EventClient.class);
-        final ConnectorDeploymentProvisioner provisioner = new ConnectorDeploymentProvisioner(config, fleetShard, fleetManager,
-            registry, eventClient);
+        final ConnectorDeploymentProvisioner provisioner = new ConnectorDeploymentProvisioner();
+        provisioner.config = ConnectorTestSupport.config();
+        ;
+        provisioner.fleetShard = ConnectorTestSupport.fleetShard(CLUSTER_ID, connectors, secrets);
+        provisioner.fleetManager = ConnectorTestSupport.fleetManagerClient();
+        provisioner.eventClient = Mockito.mock(EventClient.class);
+        provisioner.recorder = Mockito.mock(MetricsRecorder.class);
+
         final ArgumentCaptor<Secret> sc = ArgumentCaptor.forClass(Secret.class);
         final ArgumentCaptor<ManagedConnector> mcc = ArgumentCaptor.forClass(ManagedConnector.class);
 
@@ -182,8 +175,8 @@ public class ConnectorProvisionerTest {
 
         provisioner.provision(newDeployment);
 
-        verify(fleetShard).createSecret(sc.capture());
-        verify(fleetShard).createConnector(mcc.capture());
+        verify(provisioner.fleetShard).createSecret(sc.capture());
+        verify(provisioner.fleetShard).createConnector(mcc.capture());
 
         //
         // Then the existing resources must be updated to reflect the changes made to the
@@ -279,13 +272,14 @@ public class ConnectorProvisionerTest {
                     .build())
                 .build());
 
-        final FleetShardClient fleetShard = ConnectorTestSupport.fleetShard(CLUSTER_ID, connectors, secrets);
-        final FleetManagerClient fleetManager = ConnectorTestSupport.fleetManagerClient();
-        final FleetShardSyncConfig config = ConnectorTestSupport.config();
-        final MeterRegistry registry = Mockito.mock(MeterRegistry.class);
-        final EventClient eventClient = Mockito.mock(EventClient.class);
-        final ConnectorDeploymentProvisioner provisioner = new ConnectorDeploymentProvisioner(config, fleetShard, fleetManager,
-            registry, eventClient);
+        final ConnectorDeploymentProvisioner provisioner = new ConnectorDeploymentProvisioner();
+        provisioner.config = ConnectorTestSupport.config();
+        ;
+        provisioner.fleetShard = ConnectorTestSupport.fleetShard(CLUSTER_ID, connectors, secrets);
+        provisioner.fleetManager = ConnectorTestSupport.fleetManagerClient();
+        provisioner.eventClient = Mockito.mock(EventClient.class);
+        provisioner.recorder = Mockito.mock(MetricsRecorder.class);
+
         final ArgumentCaptor<Secret> sc = ArgumentCaptor.forClass(Secret.class);
         final ArgumentCaptor<ManagedConnector> mcc = ArgumentCaptor.forClass(ManagedConnector.class);
 
@@ -301,8 +295,8 @@ public class ConnectorProvisionerTest {
 
         provisioner.provision(newDeployment);
 
-        verify(fleetShard).createSecret(sc.capture());
-        verify(fleetShard).createConnector(mcc.capture());
+        verify(provisioner.fleetShard).createSecret(sc.capture());
+        verify(provisioner.fleetShard).createConnector(mcc.capture());
 
         //
         // Then the managed connector resource is expected to be updated to reflect the

--- a/etc/kubernetes/manifests/base/apps/cos-fleetshard-sync/crds/managedconnectors.cos.bf2.org-v1.yml
+++ b/etc/kubernetes/manifests/base/apps/cos-fleetshard-sync/crds/managedconnectors.cos.bf2.org-v1.yml
@@ -19,7 +19,7 @@ spec:
     - jsonPath: .spec.connectorId
       name: CONNECTOR_ID
       type: string
-    - jsonPath: .status.deployment.connectorTypeId
+    - jsonPath: .spec.deployment.connectorTypeId
       name: CONNECTOR_TYPE_ID
       type: string
     - jsonPath: .spec.deploymentId


### PR DESCRIPTION
This is aimed to replace the programmatic creation of metrics with
dependency injection where possible so calls like:

```java
var rec = MetricsRecorder.of(
    registry,
    config.metrics().baseName() + "." + METRICS_SYNC);
```

would become:

```java
@Inject
@MetricsID(METRICS_SYNC)
MetricsRecorder rec;
```

This also introduces:
- [StaticMetricsRecored](https://github.com/bf2fc6cc711aee1a0c2a/cos-fleetshard/pull/487/files#diff-3adb52b4e676caef1e92981b868b347f85393a4c721bc4eaad03ccbb0a3020ec) class for recorders that do not need to dynamically
  set tags or compute metrics name
- A [producer](https://github.com/bf2fc6cc711aee1a0c2a/cos-fleetshard/pull/487/files#diff-1d631c3fc7bffd087834357cef5b43a8988ef10b1938e536fd86ae47ac67f328R83-R110) that can inject a Counter an can save some CPU cycle as
  there's no more need to keep building and registering counter for each
  invocation.
