### PR TITLE
Mgdctrs 1379

### DIFF
--- a/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/resources/ConnectorStatusUpdater.java
+++ b/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/resources/ConnectorStatusUpdater.java
@@ -27,11 +27,11 @@ public class ConnectorStatusUpdater {
     public static final String CONNECTOR_STATE = "connector.state";
     public static final String CONNECTOR_STATE_COUNT = "connector.state.count";
 
-    static final Integer CONNECTOR_STATE_READY = 1;
-    static final Integer CONNECTOR_STATE_FAILED = 2;
-    static final Integer CONNECTOR_STATE_DELETED = 3;
-    static final Integer CONNECTOR_STATE_STOPPED = 4;
-    static final Integer CONNECTOR_STATE_IN_PROCESS = 5;
+    static final int CONNECTOR_STATE_READY = 1;
+    static final int CONNECTOR_STATE_FAILED = 2;
+    static final int CONNECTOR_STATE_DELETED = 3;
+    static final int CONNECTOR_STATE_STOPPED = 4;
+    static final int CONNECTOR_STATE_IN_PROCESS = 5;
 
     @Inject
     FleetManagerClient fleetManagerClient;
@@ -95,7 +95,7 @@ public class ConnectorStatusUpdater {
      * Also exposing a Counter metrics "cos_fleetshard_sync_connector_state_count_total" which reveals each
      * state count for the connector
      */
-    private void measure(ManagedConnector connector, Integer connectorState) {
+    private void measure(ManagedConnector connector, int connectorState) {
 
         List<Tag> tags = List.of(
             Tag.of("cos.connector.id", connector.getSpec().getConnectorId()),
@@ -118,7 +118,7 @@ public class ConnectorStatusUpdater {
             .register(registry)
             .increment();
 
-        if (CONNECTOR_STATE_FAILED.compareTo(connectorState) == 0) {
+        if (CONNECTOR_STATE_FAILED == connectorState) {
             Counter counter = registry.find(config.metrics().baseName() + "." + CONNECTOR_STATE_COUNT)
                 .tags(tags).tag("cos.connector.state", "ready").counter();
 

--- a/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/resources/ConnectorStatusUpdater.java
+++ b/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/resources/ConnectorStatusUpdater.java
@@ -53,24 +53,23 @@ public class ConnectorStatusUpdater {
             fleetManagerClient.updateConnectorStatus(connector, connectorDeploymentStatus);
 
             LOGGER.debug("Updating Connector status metrics (Connector_id: {}, state: {})",
-                connector.getSpec().getConnectorId(),
-                ConnectorStatusExtractor.extract(connector).getPhase());
+                connector.getSpec().getConnectorId(), connectorDeploymentStatus.getPhase());
 
             switch (connectorDeploymentStatus.getPhase()) {
                 case READY:
-                    measure(connector, CONNECTOR_STATE_READY);
+                    measure(connector, connectorDeploymentStatus, CONNECTOR_STATE_READY);
                     break;
                 case FAILED:
-                    measure(connector, CONNECTOR_STATE_FAILED);
+                    measure(connector, connectorDeploymentStatus, CONNECTOR_STATE_FAILED);
                     break;
                 case DELETED:
-                    measure(connector, CONNECTOR_STATE_DELETED);
+                    measure(connector, connectorDeploymentStatus, CONNECTOR_STATE_DELETED);
                     break;
                 case STOPPED:
-                    measure(connector, CONNECTOR_STATE_STOPPED);
+                    measure(connector, connectorDeploymentStatus, CONNECTOR_STATE_STOPPED);
                     break;
                 default:
-                    measure(connector, CONNECTOR_STATE_IN_PROCESS);
+                    measure(connector, connectorDeploymentStatus, CONNECTOR_STATE_IN_PROCESS);
                     break;
             }
 
@@ -95,7 +94,7 @@ public class ConnectorStatusUpdater {
      * Also exposing a Counter metrics "cos_fleetshard_sync_connector_state_count_total" which reveals each
      * state count for the connector
      */
-    private void measure(ManagedConnector connector, int connectorState) {
+    private void measure(ManagedConnector connector, ConnectorDeploymentStatus connectorDeploymentStatus, int connectorState) {
 
         List<Tag> tags = List.of(
             Tag.of("cos.connector.id", connector.getSpec().getConnectorId()),
@@ -114,7 +113,7 @@ public class ConnectorStatusUpdater {
 
         Counter.builder(config.metrics().baseName() + "." + CONNECTOR_STATE_COUNT)
             .tags(tags)
-            .tag("cos.connector.state", ConnectorStatusExtractor.extract(connector).getPhase().getValue())
+            .tag("cos.connector.state", connectorDeploymentStatus.getPhase().getValue())
             .register(registry)
             .increment();
 

--- a/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/resources/ConnectorStatusUpdater.java
+++ b/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/resources/ConnectorStatusUpdater.java
@@ -112,20 +112,20 @@ public class ConnectorStatusUpdater {
             .tags(tags)
             .register(registry);
 
-        Counter.builder(config.metrics().baseName() + "." + CONNECTOR_STATE_COUNT + ".total")
+        Counter.builder(config.metrics().baseName() + "." + CONNECTOR_STATE_COUNT)
             .tags(tags)
             .tag("cos.connector.state", ConnectorStatusExtractor.extract(connector).getPhase().getValue())
             .register(registry)
             .increment();
 
         if (CONNECTOR_STATE_FAILED.compareTo(connectorState) == 0) {
-            Counter counter = registry.find(config.metrics().baseName() + "." + CONNECTOR_STATE_COUNT + ".total")
+            Counter counter = registry.find(config.metrics().baseName() + "." + CONNECTOR_STATE_COUNT)
                 .tags(tags).tag("cos.connector.state", "ready").counter();
 
             if (counter != null && counter.count() != 0) {
 
                 // Exposing a new state "failed_but_ready" when a connector has already started but now failing
-                Counter.builder(config.metrics().baseName() + "." + CONNECTOR_STATE_COUNT + ".total")
+                Counter.builder(config.metrics().baseName() + "." + CONNECTOR_STATE_COUNT)
                     .tags(tags)
                     .tag("cos.connector.state", "failed_but_ready")
                     .register(registry)


### PR DESCRIPTION
This PR has some changes where we are exposing a counter metric to count the connector state. This will help us define Availability and Error Budget SLO in the data-plane. We have exposed a new state-failed_but_ready (just for our reference and not in the ConnectorState enum) which counts datapoint for the connectors which are failing but were ready before!