### PR TITLE
MGDCTRS-1598: Modify cos-fleetshard-sync, cos-fleetshard-operator-cam…

### DIFF
--- a/cos-fleetshard-operator-camel/README.adoc
+++ b/cos-fleetshard-operator-camel/README.adoc
@@ -16,6 +16,29 @@ kubectl create configmap cos-fleetshard-operator-camel-config \
 the provided `application.properties` is only a template, copy it somewhere and adapt the command above
 ====
 
+* override some properties
++
+There is a way to override application properties in environments where `cos-fleetshard-sync-config` configmap can not be modified (i.e. It can be useful to troubleshoot issues in an addon installations).
++
+To do so the application mounts a configmap named `cos-fleetshard-sync-config-override` as optional. If present, this can be used to override application properties. In order to enable it the env var `OVERRIDE_PROPERTIES_LOCATION` must point where the config map is mounted.
++
+An example of the configmap:
++
+[source,yaml]
+----
+apiVersion: v1
+data:
+  override.properties: |-
+    #
+    # quarkus :: log
+    #
+    quarkus.log.category."org.bf2.cos.fleetshard.sync".level = INFO
+    quarkus.log.category."org.bf2.cos.fleetshard.client".level = INFO
+    quarkus.log.category."io.fabric8.kubernetes.client.internal.VersionUsageUtils".level = ERROR
+
+    # cos.image_pull_secrets_name =
+----
+
 == local profile
 
 Start Quarkus in dev mode and read the application configuration from the current namespace.

--- a/cos-fleetshard-operator-camel/pom.xml
+++ b/cos-fleetshard-operator-camel/pom.xml
@@ -16,9 +16,11 @@
     <packaging>jar</packaging>
 
     <properties>
+        <app-config.name>${project.artifactId}-config</app-config.name>
+        <override-app-config.name>${app-config.name}-override</override-app-config.name>
+
         <!-- CRD -->
         <quarkus.kubernetes.part-of>cos</quarkus.kubernetes.part-of>
-        <quarkus.kubernetes.app-config-map>${project.artifactId}-config</quarkus.kubernetes.app-config-map>
         <quarkus.kubernetes.add-build-timestamp>false</quarkus.kubernetes.add-build-timestamp>
         <quarkus.openshift.add-build-timestamp>false</quarkus.openshift.add-build-timestamp>
 
@@ -27,6 +29,21 @@
         <quarkus.operator-sdk.crd.validate>false</quarkus.operator-sdk.crd.validate>
         <quarkus.operator-sdk.crd.apply>false</quarkus.operator-sdk.crd.apply>
         <quarkus.operator-sdk.disable-rbac-generation>true</quarkus.operator-sdk.disable-rbac-generation>
+
+        <!-- config map -->
+        <quarkus.kubernetes.config-map-volumes.app-config.config-map-name>${app-config.name}</quarkus.kubernetes.config-map-volumes.app-config.config-map-name>
+        <quarkus.kubernetes.config-map-volumes.app-config.default-mode>0644</quarkus.kubernetes.config-map-volumes.app-config.default-mode>
+        <quarkus.kubernetes.mounts.app-config.path>/mnt/app-config/configuration</quarkus.kubernetes.mounts.app-config.path>
+
+        <quarkus.kubernetes.config-map-volumes.app-config-override.config-map-name>${override-app-config.name}</quarkus.kubernetes.config-map-volumes.app-config-override.config-map-name>
+        <quarkus.kubernetes.config-map-volumes.app-config-override.default-mode>0644</quarkus.kubernetes.config-map-volumes.app-config-override.default-mode>
+        <quarkus.kubernetes.config-map-volumes.app-config-override.optional>true</quarkus.kubernetes.config-map-volumes.app-config-override.optional>
+        <quarkus.kubernetes.mounts.app-config-override.path>/mnt/app-config/override</quarkus.kubernetes.mounts.app-config-override.path>
+        <!-- enable config overlay -->
+        <quarkus.kubernetes.env.vars.OVERRIDE_PROPERTIES_LOCATION>/mnt/app-config/override/override.properties</quarkus.kubernetes.env.vars.OVERRIDE_PROPERTIES_LOCATION>
+
+        <!-- smallrye -->
+        <quarkus.kubernetes.env.vars.SMALLRYE_CONFIG_LOCATIONS>/mnt/app-config/configuration</quarkus.kubernetes.env.vars.SMALLRYE_CONFIG_LOCATIONS>
 
         <!-- kubernetes -->
         <quarkus.kubernetes-config.enabled>false</quarkus.kubernetes-config.enabled>
@@ -239,7 +256,7 @@
                                 <quarkus.log.console.format>%d{HH:mm:ss.SSS} %-5p [%c] (%t) %s%e%n</quarkus.log.console.format>
 
                                 <quarkus.kubernetes-config.enabled>true</quarkus.kubernetes-config.enabled>
-                                <quarkus.kubernetes-config.config-maps>${quarkus.kubernetes.app-config-map}</quarkus.kubernetes-config.config-maps>
+                                <quarkus.kubernetes-config.config-maps>${app-config.name}</quarkus.kubernetes-config.config-maps>
                                 <quarkus.kubernetes-config.fail-on-missing-config>false</quarkus.kubernetes-config.fail-on-missing-config>
                                 <!--
                                   The fabric8 kubernetes client is supposed to properly handle the

--- a/cos-fleetshard-operator-debezium/README.adoc
+++ b/cos-fleetshard-operator-debezium/README.adoc
@@ -16,6 +16,29 @@ kubectl create configmap cos-fleetshard-operator-debezium-config \
 the provided `application.properties` is only a template, copy it somewhere and adapt the command above
 ====
 
+* override some properties
++
+There is a way to override application properties in environments where `cos-fleetshard-sync-config` configmap can not be modified (i.e. It can be useful to troubleshoot issues in an addon installations).
++
+To do so the application mounts a configmap named `cos-fleetshard-sync-config-override` as optional. If present, this can be used to override application properties. In order to enable it the env var `OVERRIDE_PROPERTIES_LOCATION` must point where the config map is mounted.
++
+An example of the configmap:
++
+[source,yaml]
+----
+apiVersion: v1
+data:
+  override.properties: |-
+    #
+    # quarkus :: log
+    #
+    quarkus.log.category."org.bf2.cos.fleetshard.sync".level = INFO
+    quarkus.log.category."org.bf2.cos.fleetshard.client".level = INFO
+    quarkus.log.category."io.fabric8.kubernetes.client.internal.VersionUsageUtils".level = ERROR
+
+    # cos.image_pull_secrets_name =
+----
+
 == local profile
 
 Start Quarkus in dev mode and read the application configuration from the current namespace.

--- a/cos-fleetshard-operator-debezium/pom.xml
+++ b/cos-fleetshard-operator-debezium/pom.xml
@@ -15,9 +15,11 @@
     <artifactId>cos-fleetshard-operator-debezium</artifactId>
 
     <properties>
+        <app-config.name>${project.artifactId}-config</app-config.name>
+        <override-app-config.name>${app-config.name}-override</override-app-config.name>
+
         <!-- CRD -->
         <quarkus.kubernetes.part-of>cos</quarkus.kubernetes.part-of>
-        <quarkus.kubernetes.app-config-map>${project.artifactId}-config</quarkus.kubernetes.app-config-map>
         <quarkus.kubernetes.add-build-timestamp>false</quarkus.kubernetes.add-build-timestamp>
         <quarkus.openshift.add-build-timestamp>false</quarkus.openshift.add-build-timestamp>
 
@@ -26,6 +28,21 @@
         <quarkus.operator-sdk.crd.validate>false</quarkus.operator-sdk.crd.validate>
         <quarkus.operator-sdk.crd.apply>false</quarkus.operator-sdk.crd.apply>
         <quarkus.operator-sdk.disable-rbac-generation>true</quarkus.operator-sdk.disable-rbac-generation>
+
+        <!-- config map -->
+        <quarkus.kubernetes.config-map-volumes.app-config.config-map-name>${app-config.name}</quarkus.kubernetes.config-map-volumes.app-config.config-map-name>
+        <quarkus.kubernetes.config-map-volumes.app-config.default-mode>0644</quarkus.kubernetes.config-map-volumes.app-config.default-mode>
+        <quarkus.kubernetes.mounts.app-config.path>/mnt/app-config/configuration</quarkus.kubernetes.mounts.app-config.path>
+
+        <quarkus.kubernetes.config-map-volumes.app-config-override.config-map-name>${override-app-config.name}</quarkus.kubernetes.config-map-volumes.app-config-override.config-map-name>
+        <quarkus.kubernetes.config-map-volumes.app-config-override.default-mode>0644</quarkus.kubernetes.config-map-volumes.app-config-override.default-mode>
+        <quarkus.kubernetes.config-map-volumes.app-config-override.optional>true</quarkus.kubernetes.config-map-volumes.app-config-override.optional>
+        <quarkus.kubernetes.mounts.app-config-override.path>/mnt/app-config/override</quarkus.kubernetes.mounts.app-config-override.path>
+        <!-- enable config overlay -->
+        <quarkus.kubernetes.env.vars.OVERRIDE_PROPERTIES_LOCATION>/mnt/app-config/override/override.properties</quarkus.kubernetes.env.vars.OVERRIDE_PROPERTIES_LOCATION>
+
+        <!-- smallrye -->
+        <quarkus.kubernetes.env.vars.SMALLRYE_CONFIG_LOCATIONS>/mnt/app-config/configuration</quarkus.kubernetes.env.vars.SMALLRYE_CONFIG_LOCATIONS>
 
         <!-- kubernetes -->
         <quarkus.kubernetes-config.enabled>false</quarkus.kubernetes-config.enabled>
@@ -192,7 +209,7 @@
                                 <quarkus.log.console.format>%d{HH:mm:ss.SSS} %-5p [%c] (%t) %s%e%n</quarkus.log.console.format>
 
                                 <quarkus.kubernetes-config.enabled>true</quarkus.kubernetes-config.enabled>
-                                <quarkus.kubernetes-config.config-maps>${quarkus.kubernetes.app-config-map}</quarkus.kubernetes-config.config-maps>
+                                <quarkus.kubernetes-config.config-maps>${app-config.name}</quarkus.kubernetes-config.config-maps>
                                 <quarkus.kubernetes-config.fail-on-missing-config>false</quarkus.kubernetes-config.fail-on-missing-config>
 
                                 <!--

--- a/cos-fleetshard-support/src/main/java/org/bf2/cos/fleetshard/support/config/ApplicationOverrideConfigSourceProvider.java
+++ b/cos-fleetshard-support/src/main/java/org/bf2/cos/fleetshard/support/config/ApplicationOverrideConfigSourceProvider.java
@@ -1,0 +1,43 @@
+package org.bf2.cos.fleetshard.support.config;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.smallrye.config.PropertiesConfigSource;
+
+public class ApplicationOverrideConfigSourceProvider implements ConfigSourceProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationOverrideConfigSourceProvider.class);
+    private static final String OVERRIDE_PROPERTIES_LOCATION = "OVERRIDE_PROPERTIES_LOCATION";
+
+    @Override
+    public Iterable<ConfigSource> getConfigSources(ClassLoader forClassLoader) {
+        String overridePropertiesLocation = System.getenv(OVERRIDE_PROPERTIES_LOCATION);
+        if (overridePropertiesLocation == null) {
+            LOGGER.info("Properties Override support is disabled since OVERRIDE_PROPERTIES_LOCATION env var was not set.");
+            return Collections.EMPTY_LIST;
+        }
+        File f = new File(overridePropertiesLocation);
+        if (f.exists() && !f.isDirectory()) {
+            try {
+                return List
+                    .of(new PropertiesConfigSource(f.toURI().toURL(), ConfigSource.DEFAULT_ORDINAL + 1000));
+            } catch (IOException e) {
+                throw new RuntimeException(
+                    "OVERRIDE_PROPERTIES_URL config var had value " + overridePropertiesLocation
+                        + "that is not a valid url according to new File(overridePropertiesLocation).toURI().toURL().",
+                    e);
+            }
+        } else {
+            LOGGER.warn("OVERRIDE_PROPERTIES_LOCATION env var refer to a location not existent or that is not a file: {}",
+                overridePropertiesLocation);
+        }
+        return Collections.EMPTY_LIST;
+    }
+}

--- a/cos-fleetshard-support/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSourceProvider
+++ b/cos-fleetshard-support/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSourceProvider
@@ -1,0 +1,1 @@
+org.bf2.cos.fleetshard.support.config.ApplicationOverrideConfigSourceProvider

--- a/cos-fleetshard-sync/README.adoc
+++ b/cos-fleetshard-sync/README.adoc
@@ -29,6 +29,31 @@ kubectl create secret generic cos-fleetshard-sync-config \
 the provided `application.properties` is only a template, copy it somewhere and adapt the command below
 ====
 
+* override some properties
++
+There is a way to override application properties in environments where `cos-fleetshard-sync-config` configmap can not be modified (i.e. It can be useful to troubleshoot issues in an addon installations).
++
+To do so the application mounts a configmap named `cos-fleetshard-sync-config-override` as optional. If present, this can be used to override application properties. In order to enable it the env var `OVERRIDE_PROPERTIES_LOCATION` must point where the config map is mounted.
++
+An example of the configmap:
++
+[source,yaml]
+----
+apiVersion: v1
+data:
+  override.properties: |-
+    #
+    # quarkus :: log
+    #
+    quarkus.log.category."org.bf2.cos.fleetshard.sync".level = INFO
+    quarkus.log.category."org.bf2.cos.fleetshard.client".level = INFO
+    quarkus.log.category."io.fabric8.kubernetes.client.internal.VersionUsageUtils".level = ERROR
+
+    # cos.image_pull_secrets_name =
+    cos.observability.enabled = true
+----
+
+
 == local profile
 
 Start Quarkus in dev mode and read the application configuration from the current namespace.

--- a/cos-fleetshard-sync/pom.xml
+++ b/cos-fleetshard-sync/pom.xml
@@ -18,6 +18,7 @@
     <properties>
         <app-secret.name>addon-connectors-operator-parameters</app-secret.name>
         <app-config.name>cos-fleetshard-sync-config</app-config.name>
+        <override-app-config.name>${app-config.name}-override</override-app-config.name>
 
         <!-- CRD -->
         <quarkus.kubernetes.part-of>cos</quarkus.kubernetes.part-of>
@@ -30,10 +31,17 @@
         <!-- config map -->
         <quarkus.kubernetes.config-map-volumes.app-config.config-map-name>${app-config.name}</quarkus.kubernetes.config-map-volumes.app-config.config-map-name>
         <quarkus.kubernetes.config-map-volumes.app-config.default-mode>0644</quarkus.kubernetes.config-map-volumes.app-config.default-mode>
-        <quarkus.kubernetes.mounts.app-config.path>/mnt/app-config</quarkus.kubernetes.mounts.app-config.path>
+        <quarkus.kubernetes.mounts.app-config.path>/mnt/app-config/configuration</quarkus.kubernetes.mounts.app-config.path>
+
+        <quarkus.kubernetes.config-map-volumes.app-config-override.config-map-name>${override-app-config.name}</quarkus.kubernetes.config-map-volumes.app-config-override.config-map-name>
+        <quarkus.kubernetes.config-map-volumes.app-config-override.default-mode>0644</quarkus.kubernetes.config-map-volumes.app-config-override.default-mode>
+        <quarkus.kubernetes.config-map-volumes.app-config-override.optional>true</quarkus.kubernetes.config-map-volumes.app-config-override.optional>
+        <quarkus.kubernetes.mounts.app-config-override.path>/mnt/app-config/override</quarkus.kubernetes.mounts.app-config-override.path>
+        <!-- enable config overlay -->
+        <quarkus.kubernetes.env.vars.OVERRIDE_PROPERTIES_LOCATION>/mnt/app-config/override/override.properties</quarkus.kubernetes.env.vars.OVERRIDE_PROPERTIES_LOCATION>
 
         <!-- smallrye -->
-        <quarkus.kubernetes.env.vars.SMALLRYE_CONFIG_LOCATIONS>/mnt/app-config</quarkus.kubernetes.env.vars.SMALLRYE_CONFIG_LOCATIONS>
+        <quarkus.kubernetes.env.vars.SMALLRYE_CONFIG_LOCATIONS>/mnt/app-config/configuration</quarkus.kubernetes.env.vars.SMALLRYE_CONFIG_LOCATIONS>
         <quarkus.kubernetes.env.vars.SMALLRYE_CONFIG_SOURCE_FILE_LOCATIONS>/mnt/app-secret</quarkus.kubernetes.env.vars.SMALLRYE_CONFIG_SOURCE_FILE_LOCATIONS>
 
         <quarkus.kubernetes.add-build-timestamp>false</quarkus.kubernetes.add-build-timestamp>

--- a/etc/kubernetes/manifests/base/apps/cos-fleetshard-operator-camel/kubernetes.yml
+++ b/etc/kubernetes/manifests/base/apps/cos-fleetshard-operator-camel/kubernetes.yml
@@ -186,7 +186,9 @@ spec:
             fieldRef:
               fieldPath: "metadata.namespace"
         - name: "SMALLRYE_CONFIG_LOCATIONS"
-          value: "/mnt/app-config-map"
+          value: "/mnt/app-config/configuration"
+        - name: "OVERRIDE_PROPERTIES_LOCATION"
+          value: "/mnt/app-config/override/override.properties"
         image: "quay.io/rhoas/cos-fleetshard-operator-camel:latest"
         imagePullPolicy: "Always"
         livenessProbe:
@@ -222,12 +224,21 @@ spec:
             cpu: "500m"
             memory: "600Mi"
         volumeMounts:
-        - mountPath: "/mnt/app-config-map"
-          name: "app-config-map"
+        - mountPath: "/mnt/app-config/configuration"
+          name: "app-config"
+          readOnly: false
+        - mountPath: "/mnt/app-config/override"
+          name: "app-config-override"
           readOnly: false
       serviceAccountName: "cos-fleetshard-operator-camel"
       volumes:
       - configMap:
+          defaultMode: 420
           name: "cos-fleetshard-operator-camel-config"
           optional: false
-        name: "app-config-map"
+        name: "app-config"
+      - configMap:
+          defaultMode: 420
+          name: "cos-fleetshard-operator-camel-config-override"
+          optional: true
+        name: "app-config-override"

--- a/etc/kubernetes/manifests/base/apps/cos-fleetshard-operator-debezium/kubernetes.yml
+++ b/etc/kubernetes/manifests/base/apps/cos-fleetshard-operator-debezium/kubernetes.yml
@@ -187,7 +187,9 @@ spec:
             fieldRef:
               fieldPath: "metadata.namespace"
         - name: "SMALLRYE_CONFIG_LOCATIONS"
-          value: "/mnt/app-config-map"
+          value: "/mnt/app-config/configuration"
+        - name: "OVERRIDE_PROPERTIES_LOCATION"
+          value: "/mnt/app-config/override/override.properties"
         image: "quay.io/rhoas/cos-fleetshard-operator-debezium:latest"
         imagePullPolicy: "Always"
         livenessProbe:
@@ -223,12 +225,21 @@ spec:
             cpu: "500m"
             memory: "512Mi"
         volumeMounts:
-        - mountPath: "/mnt/app-config-map"
-          name: "app-config-map"
+        - mountPath: "/mnt/app-config/configuration"
+          name: "app-config"
+          readOnly: false
+        - mountPath: "/mnt/app-config/override"
+          name: "app-config-override"
           readOnly: false
       serviceAccountName: "cos-fleetshard-operator-debezium"
       volumes:
       - configMap:
+          defaultMode: 420
           name: "cos-fleetshard-operator-debezium-config"
           optional: false
-        name: "app-config-map"
+        name: "app-config"
+      - configMap:
+          defaultMode: 420
+          name: "cos-fleetshard-operator-debezium-config-override"
+          optional: true
+        name: "app-config-override"

--- a/etc/kubernetes/manifests/base/apps/cos-fleetshard-sync/kubernetes.yml
+++ b/etc/kubernetes/manifests/base/apps/cos-fleetshard-sync/kubernetes.yml
@@ -410,10 +410,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: "metadata.namespace"
+        - name: "SMALLRYE_CONFIG_LOCATIONS"
+          value: "/mnt/app-config/configuration"
         - name: "SMALLRYE_CONFIG_SOURCE_FILE_LOCATIONS"
           value: "/mnt/app-secret"
-        - name: "SMALLRYE_CONFIG_LOCATIONS"
-          value: "/mnt/app-config"
+        - name: "OVERRIDE_PROPERTIES_LOCATION"
+          value: "/mnt/app-config/override/override.properties"
         image: "quay.io/rhoas/cos-fleetshard-sync:latest"
         imagePullPolicy: "Always"
         livenessProbe:
@@ -449,8 +451,11 @@ spec:
             cpu: "100m"
             memory: "400Mi"
         volumeMounts:
-        - mountPath: "/mnt/app-config"
+        - mountPath: "/mnt/app-config/configuration"
           name: "app-config"
+          readOnly: false
+        - mountPath: "/mnt/app-config/override"
+          name: "app-config-override"
           readOnly: false
         - mountPath: "/mnt/app-secret"
           name: "app-secret"
@@ -467,3 +472,8 @@ spec:
           name: "cos-fleetshard-sync-config"
           optional: false
         name: "app-config"
+      - configMap:
+          defaultMode: 420
+          name: "cos-fleetshard-sync-config-override"
+          optional: true
+        name: "app-config-override"


### PR DESCRIPTION
…el and cos-fleetshard-operator-debezium to make it possible to change log lever to DEBUG

This commit actually enables a configmap based override sysetem that can be used to change any application property not just the log level.

Admittedly this PR lack tests, but I have not found a good way to do it given how tests are structured. If anyone has any idea happy to try it.