### PR TITLE
Fix typo preventing sync to start when cos.observability.environment secret is found

### DIFF
--- a/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/client/FleetShardObservabilityClient.java
+++ b/cos-fleetshard-sync/src/main/java/org/bf2/cos/fleetshard/sync/client/FleetShardObservabilityClient.java
@@ -81,7 +81,7 @@ public class FleetShardObservabilityClient {
             obsSecret.setData(fromSecret.getData());
             kubernetesClient.secrets()
                 .inNamespace(obsSecret.getMetadata().getNamespace())
-                .withName(obsSecret.getMetadata().getNamespace())
+                .withName(obsSecret.getMetadata().getName())
                 .createOrReplace(obsSecret);
         } else {
             LOGGER.warn("Observatorium secret for environment {} not found.", config.observability().environment());


### PR DESCRIPTION
Interestingly the tests didn't fail and in dev the problem is not present 🤔 

Fixes https://github.com/bf2fc6cc711aee1a0c2a/cos-fleetshard/issues/536