### PR TITLE
chore: include migrate field

### DIFF
--- a/cos-fleetshard-api/model/src/main/java/com/redhat/observability/v1/ObservabilityStatus.java
+++ b/cos-fleetshard-api/model/src/main/java/com/redhat/observability/v1/ObservabilityStatus.java
@@ -68,6 +68,18 @@ public class ObservabilityStatus implements io.fabric8.kubernetes.api.model.Kube
         this.stageStatus = stageStatus;
     }
 
+    @com.fasterxml.jackson.annotation.JsonProperty("migrated")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private boolean migrated;
+
+    public boolean getMigrated() {
+        return migrated;
+    }
+
+    public void setMigrated(boolean migrated) {
+        this.migrated = migrated;
+    }
+
     @com.fasterxml.jackson.annotation.JsonProperty("tokenExpires")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
     private Long tokenExpires;


### PR DESCRIPTION
Version 4 of the Observability Operator [introduces the field `Migrated` in the CRD Status block](https://github.com/redhat-developer/observability-operator/blob/main/api/v1/observability_types.go#L128) and this needs to be reflected on the sync