### PR TITLE
disable java-operator-sdk internal metrics

### DIFF
--- a/cos-fleetshard-it/cucumber/src/main/java/org/bf2/cos/fleetshard/it/cucumber/MicrometerSteps.java
+++ b/cos-fleetshard-it/cucumber/src/main/java/org/bf2/cos/fleetshard/it/cucumber/MicrometerSteps.java
@@ -205,6 +205,15 @@ public class MicrometerSteps extends StepsSupport {
             .isGreaterThan(0);
     }
 
+    @And("the meters does not have entries with name matching {string}")
+    public void meter_does_not_exists(String regex) {
+        assertThat(registry.getMeters()).allSatisfy(meter -> {
+            assertThat(meter.getId().getName().matches(regex))
+                .withFailMessage(() -> String.format("There is a meter %s matching '%s'", meter.getId().getName(), regex))
+                .isFalse();
+        });
+    }
+
     // ***********************************
     //
     // timers

--- a/cos-fleetshard-operator-camel-it/src/test/java/org/bf2/cos/fleetshard/operator/it/camel/CamelConnectorMetricsTest.java
+++ b/cos-fleetshard-operator-camel-it/src/test/java/org/bf2/cos/fleetshard/operator/it/camel/CamelConnectorMetricsTest.java
@@ -1,0 +1,31 @@
+package org.bf2.cos.fleetshard.operator.it.camel;
+
+import java.util.Map;
+
+import io.quarkiverse.cucumber.CucumberOptions;
+import io.quarkiverse.cucumber.CucumberQuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+import static org.bf2.cos.fleetshard.support.resources.Resources.uid;
+
+@CucumberOptions(
+    features = {
+        "classpath:CamelConnectorMetrics.feature"
+    },
+    glue = {
+        "org.bf2.cos.fleetshard.it.cucumber",
+        "org.bf2.cos.fleetshard.operator.it.camel.glues"
+    })
+@TestProfile(CamelConnectorMetricsTest.Profile.class)
+public class CamelConnectorMetricsTest extends CucumberQuarkusTest {
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            final String ns = "cos-camel-" + uid();
+
+            return Map.of(
+                "cos.namespace", ns);
+        }
+    }
+}

--- a/cos-fleetshard-operator-camel-it/src/test/resources/CamelConnectorMetrics.feature
+++ b/cos-fleetshard-operator-camel-it/src/test/resources/CamelConnectorMetrics.feature
@@ -1,0 +1,24 @@
+Feature: Camel Connector Metrics
+
+  Background:
+    Given Await configuration
+      | atMost       | 30000   |
+      | pollDelay    | 100     |
+      | pollInterval | 500     |
+
+  Scenario: stop
+    Given a Connector with:
+      | connector.type.id           | log_sink_0.1                    |
+      | desired.state               | ready                           |
+      | kafka.bootstrap             | kafka.acme.com:443              |
+      | operator.id                 | cos-fleetshard-operator-camel   |
+      | operator.type               | camel-connector-operator        |
+      | operator.version            | [1.0.0,2.0.0)                   |
+    And with sample camel connector
+
+    When deploy
+    Then the connector exists
+     And the connector secret exists
+     And the connector is in phase "Monitor"
+     And the meters does not have entries with name matching "operator.sdk.*"
+

--- a/cos-fleetshard-operator-debezium-it/src/test/java/org/bf2/cos/fleetshard/operator/it/debezium/DebeziumConnectorMetricsTest.java
+++ b/cos-fleetshard-operator-debezium-it/src/test/java/org/bf2/cos/fleetshard/operator/it/debezium/DebeziumConnectorMetricsTest.java
@@ -1,0 +1,31 @@
+package org.bf2.cos.fleetshard.operator.it.debezium;
+
+import java.util.Map;
+
+import io.quarkiverse.cucumber.CucumberOptions;
+import io.quarkiverse.cucumber.CucumberQuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+import static org.bf2.cos.fleetshard.support.resources.Resources.uid;
+
+@CucumberOptions(
+    features = {
+        "classpath:DebeziumConnectorMetrics.feature"
+    },
+    glue = {
+        "org.bf2.cos.fleetshard.it.cucumber",
+        "org.bf2.cos.fleetshard.operator.it.debezium.glues"
+    })
+@TestProfile(DebeziumConnectorMetricsTest.Profile.class)
+public class DebeziumConnectorMetricsTest extends CucumberQuarkusTest {
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            final String ns = "cos-debezium-" + uid();
+
+            return Map.of(
+                "cos.namespace", ns);
+        }
+    }
+}

--- a/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorMetrics.feature
+++ b/cos-fleetshard-operator-debezium-it/src/test/resources/DebeziumConnectorMetrics.feature
@@ -1,0 +1,23 @@
+Feature: Debezium Connector Metrics
+
+  Background:
+    Given Await configuration
+      | atMost       | 30000   |
+      | pollDelay    | 100     |
+      | pollInterval | 500     |
+
+  Scenario: stop
+    Given a Connector with:
+      | connector.type.id           | debezium-postgres-1.9.4.Final    |
+      | desired.state               | ready                            |
+      | kafka.bootstrap             | kafka.acme.com:443               |
+      | operator.id                 | cos-fleetshard-operator-debezium |
+      | operator.type               | debezium-connector-operator      |
+      | operator.version            | [1.0.0,2.0.0)                    |
+    And with a simple Debezium connector
+
+    When deploy
+    Then the connector exists
+     And the connector secret exists
+     And the connector is in phase "Monitor"
+     And the meters does not have entries with name matching "operator.sdk.*"

--- a/cos-fleetshard-operator/src/main/java/org/bf2/cos/fleetshard/operator/FleetShardProducers.java
+++ b/cos-fleetshard-operator/src/main/java/org/bf2/cos/fleetshard/operator/FleetShardProducers.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.enterprise.inject.Produces;
-import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.bf2.cos.fleetshard.api.ManagedConnectorOperator;
@@ -12,15 +11,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.javaoperatorsdk.operator.api.config.InformerStoppedHandler;
+import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.quarkus.arc.Unremovable;
 
 public class FleetShardProducers {
     private static final Logger LOGGER = LoggerFactory.getLogger(FleetShardProducers.class);
-
-    @Inject
-    FleetShardOperatorConfig config;
 
     @SuppressWarnings("PMD.DoNotTerminateVM")
     @Singleton
@@ -53,6 +51,22 @@ public class FleetShardProducers {
         });
 
         return MeterFilter.commonTags(tags);
+    }
+
+    @Produces
+    @Singleton
+    @Unremovable
+    public Metrics getMetrics() {
+        return Metrics.NOOP;
+    }
+
+    @Produces
+    @Singleton
+    @Unremovable
+    public MeterBinder getMeterBinder() {
+        return registry -> {
+            // Do noting
+        };
     }
 
 }

--- a/etc/kubernetes/manifests/base/apps/cos-fleetshard-operator-camel/kubernetes.yml
+++ b/etc/kubernetes/manifests/base/apps/cos-fleetshard-operator-camel/kubernetes.yml
@@ -158,8 +158,8 @@ spec:
             path: "/q/health/live"
             port: 8080
             scheme: "HTTP"
-          initialDelaySeconds: 0
-          periodSeconds: 30
+          initialDelaySeconds: 5
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 10
         name: "cos-fleetshard-operator-camel"
@@ -173,8 +173,8 @@ spec:
             path: "/q/health/ready"
             port: 8080
             scheme: "HTTP"
-          initialDelaySeconds: 0
-          periodSeconds: 30
+          initialDelaySeconds: 5
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 10
         resources:

--- a/etc/kubernetes/manifests/base/apps/cos-fleetshard-operator-debezium/kubernetes.yml
+++ b/etc/kubernetes/manifests/base/apps/cos-fleetshard-operator-debezium/kubernetes.yml
@@ -159,8 +159,8 @@ spec:
             path: "/q/health/live"
             port: 8080
             scheme: "HTTP"
-          initialDelaySeconds: 0
-          periodSeconds: 30
+          initialDelaySeconds: 5
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 10
         name: "cos-fleetshard-operator-debezium"
@@ -174,8 +174,8 @@ spec:
             path: "/q/health/ready"
             port: 8080
             scheme: "HTTP"
-          initialDelaySeconds: 0
-          periodSeconds: 30
+          initialDelaySeconds: 5
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 10
         resources:

--- a/etc/kubernetes/manifests/base/apps/cos-fleetshard-sync/crds/managedconnectors.cos.bf2.org-v1.yml
+++ b/etc/kubernetes/manifests/base/apps/cos-fleetshard-sync/crds/managedconnectors.cos.bf2.org-v1.yml
@@ -22,6 +22,9 @@ spec:
     - jsonPath: .spec.deployment.connectorTypeId
       name: CONNECTOR_TYPE_ID
       type: string
+    - jsonPath: .spec.deployment.connectorTypeId
+      name: CONNECTOR_TYPE_ID
+      type: string
     - jsonPath: .spec.deploymentId
       name: DEPLOYMENT_ID
       type: string

--- a/etc/kubernetes/manifests/base/apps/cos-fleetshard-sync/kubernetes.yml
+++ b/etc/kubernetes/manifests/base/apps/cos-fleetshard-sync/kubernetes.yml
@@ -393,8 +393,8 @@ spec:
             path: "/q/health/live"
             port: 8080
             scheme: "HTTP"
-          initialDelaySeconds: 0
-          periodSeconds: 30
+          initialDelaySeconds: 5
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 10
         name: "cos-fleetshard-sync"
@@ -408,8 +408,8 @@ spec:
             path: "/q/health/ready"
             port: 8080
             scheme: "HTTP"
-          initialDelaySeconds: 0
-          periodSeconds: 30
+          initialDelaySeconds: 5
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 10
         resources:

--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,9 @@
         <jakarta-annotation-api.version>1.3.5</jakarta-annotation-api.version>
         <jsr305.version>3.0.2</jsr305.version>
         <lombok.version>1.18.26</lombok.version>
-        <quarkus.version>2.15.0.Final</quarkus.version>
+        <quarkus.version>2.16.4.Final</quarkus.version>
         <quarkus-cucumber.version>0.6.0</quarkus-cucumber.version>
-        <quarkus-operator-sdk.version>5.0.2</quarkus-operator-sdk.version>
+        <quarkus-operator-sdk.version>5.1.1</quarkus-operator-sdk.version>
         <swagger-annotations.version>1.6.9</swagger-annotations.version>
         <sundrio.version>0.93.1</sundrio.version>
         <wiremock.version>2.35.0</wiremock.version>


### PR DESCRIPTION
- chore(deps): update to quarkus-operator-sdk 5.1.1
- feat: disable java-operator-sdk internal metrics
